### PR TITLE
fix: 输入法按 Enter 误发送 + 流式 Markdown 表格不渲染

### DIFF
--- a/src/renderer/src/features/composer/use-composer-keydown.ts
+++ b/src/renderer/src/features/composer/use-composer-keydown.ts
@@ -49,6 +49,9 @@ export function useComposerKeyDown(opts: {
         handleSend,
         runComposerAbort,
       } = opts
+      // 输入法正在组词时（含按 Enter 选词的瞬间），交给 IME 处理，不触发任何快捷键/发送
+      if (e.nativeEvent.isComposing || e.keyCode === 229) return
+
       const alt = e.altKey
       if (
         !showPopover &&

--- a/src/renderer/src/features/timeline/markdown-view.tsx
+++ b/src/renderer/src/features/timeline/markdown-view.tsx
@@ -111,6 +111,21 @@ const REHYPE_PLUGINS: Pluggable[] = [
 
 const STREAM_PLAIN_ONLY_MAX = 96
 
+/**
+ * 流式尾部是否含块级语法（表格/标题/列表/引用/代码块）。
+ * 这些结构在纯文本尾部会显示成原始符号，需要走 Markdown 渲染才能实时成型。
+ */
+function tailHasBlockSyntax(text: string): boolean {
+  if (!text) return false
+  return (
+    /(^|\n)\s{0,3}#{1,6}\s/.test(text) || // 标题
+    /(^|\n)\s{0,3}>/.test(text) || // 引用
+    /(^|\n)\s{0,3}([-*+]\s|\d+[.)]\s)/.test(text) || // 列表
+    /(^|\n)\s{0,3}```/.test(text) || // 代码块
+    /(^|\n)\s{0,3}\|/.test(text) // 表格行（含分隔行，行首以 | 开头）
+  )
+}
+
 const MarkdownView = memo(function MarkdownView({
   children,
   className,
@@ -139,7 +154,11 @@ const MarkdownView = memo(function MarkdownView({
   const committedPrefix = streaming ? committedStableRef.current : ''
   const liveTail = streaming ? children.slice(committedPrefix.length) : ''
   const usePlainStream =
-    !!streaming && !committedPrefix && liveTail.length > 0 && liveTail.length <= STREAM_PLAIN_ONLY_MAX
+    !!streaming &&
+    !committedPrefix &&
+    liveTail.length > 0 &&
+    liveTail.length <= STREAM_PLAIN_ONLY_MAX &&
+    !tailHasBlockSyntax(liveTail)
 
   const markdown = useMemo(
     () =>
@@ -256,7 +275,19 @@ const MarkdownView = memo(function MarkdownView({
             {committedMd}
           </ReactMarkdown>
         ) : null}
-        {liveTail ? <StreamLiveTailBlock text={liveTail} streaming /> : null}
+        {liveTail ? (
+          tailHasBlockSyntax(liveTail) ? (
+            <ReactMarkdown
+              remarkPlugins={buildRemarkPlugins(false)}
+              rehypePlugins={REHYPE_PLUGINS}
+              components={components}
+            >
+              {preprocessMarkdownMath(liveTail, { streaming: false })}
+            </ReactMarkdown>
+          ) : (
+            <StreamLiveTailBlock text={liveTail} streaming />
+          )
+        ) : null}
       </div>
     )
   }


### PR DESCRIPTION
hello justhil佬 👋 提两个小修复，都是 UI 体验问题：

## 1. 输入法组词时按 Enter 选词会误发送消息
- **原因**：composer 的 keydown 只判断 `e.key`，未检查 `isComposing`。用输入法打字时按 Enter 确认候选词，会同时触发消息发送。
- **修复**：在按键处理开头加闸门——组词期间（含 `keyCode === 229` 兜底）一律放行交给 IME，不触发发送/快捷键。

## 2. 流式输出时表格等块级 Markdown 不渲染，显示成竖线原文
- **原因**：流式把内容拆成「稳定前缀(Markdown) + 实时尾部(纯文本)」。表格是一整块，在它后面出现空行之前一直留在纯文本尾部，于是显示成 `| 水果 | 颜色 |` 原文，要等本轮结束才变成真表格。
- **修复**：新增 `tailHasBlockSyntax()` 检测尾部是否含表格/标题/列表/引用/代码块，若含则尾部也走 `ReactMarkdown` 渲染；纯文字段落仍走原纯文本+渐显，保持流畅。

## 验证
- `npm run typecheck` / `lint` / `build` / `test:unit` 全过
- 本地实机验证：中文输入法按 Enter 选词不再发送；表格流式过程中即时成型

## 改动规模
2 个文件，净增约 34 行。

<!-- screenshot below -->
![修复效果](https://raw.githubusercontent.com/Wing900/pi-app/main/assets/pr-screenshots/ime-and-table-fix.png)
