### PR TITLE
修复：ai对话完成后状态残留、问答弹窗偶发不弹/卡死、新建对话信息跳最近会话

### DIFF
--- a/packages/shared/ipc-channels.ts
+++ b/packages/shared/ipc-channels.ts
@@ -29,6 +29,7 @@ export const IPC_INVOKE_CHANNELS = [
   'ipc:extension.config.get',
   'ipc:extension.config.set',
   'ipc:extension.respondUI',
+  'ipc:extension.cancelUI',
   'ipc:extensions.list',
   'ipc:extensions.missingRuntimePackages',
   'ipc:extensions.setEnabled',

--- a/src/main/ipc/handlers/extension-ui.ts
+++ b/src/main/ipc/handlers/extension-ui.ts
@@ -8,6 +8,11 @@ export function registerExtensionUiHandlers(): void {
     return { ok: true }
   })
 
+  registerHandler('ipc:extension.cancelUI', async (req) => {
+    workerManager.cancelExtensionUI(req?.id, req?.reason ?? 'renderer-cancel')
+    return { ok: true }
+  })
+
   registerHandler('ipc:extension.config.get', async (req) => {
     const workspaceId = req.workspaceId || workerManager.cwd || configStore.get('currentProject') || ''
     return { config: configStore.getExtensionConfig(workspaceId, req.extensionId) || {} }

--- a/src/main/worker-manager-pool.ts
+++ b/src/main/worker-manager-pool.ts
@@ -7,6 +7,13 @@ import type { WorkerInitResult, WorkerSlot } from './worker-manager-types'
 import { readMaxSessionWorkers, minutesToIdleDelayMs, readSessionWorkerIdleTimeoutMinutes } from './worker-pool-config'
 import { normalizeSessionKey, workspacePoolKey } from './worker-session-key'
 
+/**
+ * Tracks which worker slot owns each in-flight extension UI dialog (id → poolKey).
+ * Registered when a request is forwarded to the renderer, so responses and cancels
+ * can be routed back to the originating slot instead of only the foreground one.
+ */
+export const extensionUiDialogSource = new Map<string, string>()
+
 function createSlot(
   poolKey: string,
   cwd: string,
@@ -92,7 +99,7 @@ export function attachWorkerHandlers(
       agentTurnActive: boolean
     }) => void
     onSlotExit: (slot: WorkerSlot, code: number) => void
-    /** When set, only forward extension UI from this pool key (X1). */
+    /** When set, only notify-type extension UI is forwarded from non-foreground slots. */
     getForegroundPoolKey?: () => string | null
   },
 ): void {
@@ -145,28 +152,30 @@ export function attachWorkerHandlers(
       win &&
       !win.isDestroyed()
     ) {
-      const fg = opts.getForegroundPoolKey?.() ?? null
-      if (fg && fg !== slot.poolKey) {
-        // X1: only foreground session dismiss noise
-      } else {
-        win.webContents.send('ipc:extension-ui-dismiss', {
-          type: data.type,
-          id: data.id,
-          reason: data.reason,
-        })
-      }
+      // Drop the foreground gate: a background worker's dialog may be dismissed
+      // (timeout/abort/compaction) while its own slot is not foreground.
+      const dialogId = typeof data.id === 'string' ? data.id : undefined
+      if (dialogId && extensionUiDialogSource.has(dialogId)) extensionUiDialogSource.delete(dialogId)
+      win.webContents.send('ipc:extension-ui-dismiss', {
+        type: data.type,
+        id: data.id,
+        reason: data.reason,
+      })
     }
 
     if (data.type === 'extension-ui-request' && win && !win.isDestroyed()) {
-      const req = data.request as { method?: string; notifyType?: string; message?: string }
+      const req = data.request as { id?: string; method?: string; notifyType?: string; message?: string }
       const method = req?.method || ''
       const fg = opts.getForegroundPoolKey?.() ?? null
       const isForeground = !fg || fg === slot.poolKey
-      if (!isForeground && method !== 'notify') return
+      // Dialog requests from any slot must reach the renderer — background agents
+      // calling ask_user_question/select/confirm would otherwise never show a popup.
       const allow =
         method !== 'notify' || slot.agentTurnActive || req.notifyType === 'error'
       if (!allow) return
-      if (!isForeground && req.notifyType !== 'error') return
+      // Non-foreground notify stays gated (except errors) to avoid toast noise.
+      if (!isForeground && method === 'notify' && req.notifyType !== 'error') return
+      if (req?.id) extensionUiDialogSource.set(req.id, slot.poolKey)
       win.webContents.send('ipc:extension-ui-request', data.request)
     }
 

--- a/src/main/worker-manager.ts
+++ b/src/main/worker-manager.ts
@@ -21,6 +21,7 @@ import {
   canAcquireNewWorker,
   disposeWorkerSlot,
   evictIdleWorkers,
+  extensionUiDialogSource,
   forkWorkerForCwd,
   getBackgroundWorkerState,
   pruneIdleWorkersByTimeout,
@@ -735,9 +736,33 @@ export class WorkerManager {
     cancelled?: boolean
     result?: unknown
   }): void {
-    const slot = this.foregroundSlot()
-    if (!slot) return
+    // Route the response back to the slot that owns this dialog (registered when the
+    // request was forwarded); fall back to the foreground slot when unknown/stopping.
+    let slot: WorkerSlot | null = null
+    const id = response.id
+    const poolKey = id ? extensionUiDialogSource.get(id) : undefined
+    if (poolKey) {
+      slot = this.pool.get(poolKey) ?? null
+      extensionUiDialogSource.delete(id)
+    }
+    if (!slot || slot.stopping) slot = this.foregroundSlot()
+    if (!slot || slot.stopping) return
     slot.worker.postMessage({ type: 'extension-ui-response', response })
+  }
+
+  /** Tell the originating worker that its pending dialog was cancelled by the renderer. */
+  cancelExtensionUI(id: string | undefined, reason: string): void {
+    let slot: WorkerSlot | null = null
+    if (id) {
+      const poolKey = extensionUiDialogSource.get(id)
+      if (poolKey) {
+        slot = this.pool.get(poolKey) ?? null
+        extensionUiDialogSource.delete(id)
+      }
+    }
+    if (!slot || slot.stopping) slot = this.foregroundSlot()
+    if (!slot || slot.stopping) return
+    slot.worker.postMessage({ type: 'extension-ui-cancel', cancel: { id, reason } })
   }
 
   get isRunning(): boolean {

--- a/src/renderer/src/features/workspace/project-sidebar.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar.tsx
@@ -177,6 +177,10 @@ export function ProjectSidebar({
         const store = useUIStore.getState()
         store.clearPendingNewSessionPlaceholder()
         store.setCurrentSession(null)
+        // Clear the stale worker snapshot: while the placeholder is open the worker
+        // is still bound to the previous session, and a stale snapshot would route
+        // that session's events as visible (new session jumping to the most recent).
+        store.setWorkerLiveSnapshot({ sessionId: null, sessionFile: null, status: 'idle' })
         store.clearTimeline()
         store.clearFileChanges()
         store.setHistoryMeta(0, 0, null)

--- a/src/renderer/src/lib/__tests__/session-worker-sync.test.ts
+++ b/src/renderer/src/lib/__tests__/session-worker-sync.test.ts
@@ -205,4 +205,45 @@ describe('session-worker-sync', () => {
     expect(snap).toEqual({ sessionId: null, sessionFile: '/b.jsonl', status: 'idle' })
     expect(runStatus).toBeNull()
   })
+
+  it('reconciles stale optimistic markers when bound worker is idle for the viewed session', () => {
+    const reconciled: string[] = []
+    const runtimeFlags: Array<[string, boolean]> = []
+    applyLiveSnapshotToView(
+      '/view.jsonl',
+      { sessionId: 's1', sessionFile: '/view.jsonl', status: 'idle' },
+      {
+        historySessionFile: '/view.jsonl',
+        runState: { status: 'idle', toolCount: 0, errorCount: 0 },
+        setWorkerLiveSnapshot: () => {},
+        setRunState: () => {},
+        reconcileIdleMarkers: () => {
+          reconciled.push('reconcile')
+        },
+        setSessionRuntimeRunning: (f, running) => {
+          runtimeFlags.push([f, running])
+        },
+      },
+    )
+    expect(reconciled).toEqual(['reconcile'])
+    expect(runtimeFlags).toEqual([['/view.jsonl', false]])
+  })
+
+  it('does not reconcile when the bound worker is still running', () => {
+    let reconciled = false
+    applyLiveSnapshotToView(
+      '/view.jsonl',
+      { sessionId: 's1', sessionFile: '/view.jsonl', status: 'running' },
+      {
+        historySessionFile: '/view.jsonl',
+        runState: { status: 'running', toolCount: 0, errorCount: 0 },
+        setWorkerLiveSnapshot: () => {},
+        setRunState: () => {},
+        reconcileIdleMarkers: () => {
+          reconciled = true
+        },
+      },
+    )
+    expect(reconciled).toBe(false)
+  })
 })

--- a/src/renderer/src/lib/session-worker-sync.ts
+++ b/src/renderer/src/lib/session-worker-sync.ts
@@ -198,6 +198,9 @@ type ViewStore = {
   runState: RunState
   setWorkerLiveSnapshot: (snap: WorkerLiveSnapshot) => void
   setRunState: (patch: Partial<RunState>) => void
+  /** Optional: clear stale optimistic markers once the bound worker is provably idle. */
+  reconcileIdleMarkers?: () => void
+  setSessionRuntimeRunning?: (sessionFile: string, running: boolean) => void
 }
 
 /**
@@ -233,6 +236,20 @@ export function applyLiveSnapshotToView(
 
   store.setWorkerLiveSnapshot(boundSnap)
   syncViewRunStateFromWorkerSnapshot(viewSessionFile, boundSnap, (p) => store.setRunState(p))
+
+  // Reconcile: when the bound worker is idle for the viewed session, clear the
+  // optimistic send markers (streamingAssistantId / optimisticPendingUserText /
+  // agentTurnBootstrapping) that can survive a mid-turn session switch and leave
+  // the composer stuck on "conversation in progress".
+  if (
+    boundSnap.status !== 'running' &&
+    boundSnap.sessionFile &&
+    viewSessionFile &&
+    sessionFilesEqual(boundSnap.sessionFile, viewSessionFile)
+  ) {
+    store.reconcileIdleMarkers?.()
+    store.setSessionRuntimeRunning?.(viewSessionFile, false)
+  }
 }
 
 export function resetVisibleComposerTurnState(set: {

--- a/src/renderer/src/stores/__tests__/apply-app-event-route.test.ts
+++ b/src/renderer/src/stores/__tests__/apply-app-event-route.test.ts
@@ -130,4 +130,52 @@ describe('resolveAppEventRoute', () => {
       ),
     ).toBe('background')
   })
+
+  it('backgrounds old-session events during pending new-session placeholder', () => {
+    expect(
+      resolveAppEventRoute(
+        {
+          currentWorkspace: '/w/preview',
+          currentSessionId: '__pending_new__',
+          historySessionFile: null,
+          workerLiveSnapshot: { sessionId: 'w-old', sessionFile: '/tmp/old.jsonl' },
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          phase: 'delta',
+          text: 'stale',
+          seq: 1,
+          workspaceId: '/w/preview',
+          sessionFile: '/tmp/old.jsonl',
+          sessionId: 'w-old',
+          timestamp: 1,
+        },
+      ),
+    ).toBe('background')
+  })
+
+  it('backgrounds events on Home (no session selected) even when worker matches evFile', () => {
+    expect(
+      resolveAppEventRoute(
+        {
+          currentWorkspace: '/w/preview',
+          currentSessionId: null,
+          historySessionFile: null,
+          workerLiveSnapshot: { sessionId: 'w-old', sessionFile: '/tmp/old.jsonl' },
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          phase: 'delta',
+          text: 'stale',
+          seq: 1,
+          workspaceId: '/w/preview',
+          sessionFile: '/tmp/old.jsonl',
+          sessionId: 'w-old',
+          timestamp: 1,
+        },
+      ),
+    ).toBe('background')
+  })
 })

--- a/src/renderer/src/stores/apply-app-event-route.ts
+++ b/src/renderer/src/stores/apply-app-event-route.ts
@@ -1,5 +1,6 @@
 import type { SessionScopedAppEvent } from '@shared/app-event-session'
 import { sessionFilesEqual } from '@renderer/lib/session-file-key'
+import { PENDING_NEW_SESSION_ID } from '@renderer/lib/session-ids'
 
 export type AppEventRoute = 'visible' | 'background' | 'drop'
 
@@ -24,6 +25,12 @@ export function resolveAppEventRoute(state: RouteState, event: SessionScopedAppE
   const viewSid = state.currentSessionId
   const workerSid = state.workerLiveSnapshot.sessionId
   const evSid = event.sessionId
+
+  // Pending-new-session placeholder (not yet materialized) or Home (no bound
+  // session): viewFile is empty, so the old workerFile==evFile match would draw
+  // the previous session's events into the blank timeline (new session jumping to
+  // the most recent). Route everything to background until a real session binds.
+  if (!viewFile && (!viewSid || viewSid === PENDING_NEW_SESSION_ID)) return 'background'
 
   if (evFile) {
     if (viewFile && sessionFilesEqual(evFile, viewFile)) return 'visible'

--- a/src/renderer/src/stores/extension-ui-store.ts
+++ b/src/renderer/src/stores/extension-ui-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { useUIStore } from '@renderer/stores/ui-store'
+import { ipcClient } from '@renderer/lib/ipc-client'
 import type { AskQuestionPayload } from '@renderer/features/extension-ui/questionnaire-dialog'
 import type { ImageReviewPayload } from '@renderer/features/extension-ui/image-review-dialog'
 
@@ -77,11 +78,23 @@ export const useExtensionUIStore = create<ExtensionUIState>((set, get) => ({
     set({ activePending: s.pending, suspended: null })
   },
 
-  clearAfterRespond: () => set({ activePending: null, suspended: null }),
+  clearAfterRespond: () => {
+    const active = get().activePending
+    if (active?.id) {
+      // Tell the worker its pending dialog is gone, so its promise doesn't hang
+      // the turn when the response was routed to the wrong slot or never arrived.
+      void ipcClient.invoke('extension.cancelUI', { id: active.id, reason: 'renderer-clear' }).catch(() => {})
+    }
+    set({ activePending: null, suspended: null })
+  },
 
   pruneStaleSuspension: () => pruneStaleSuspension(),
 
   resetForSessionContext: () => {
+    const active = get().activePending
+    if (active?.id) {
+      void ipcClient.invoke('extension.cancelUI', { id: active.id, reason: 'session-reset' }).catch(() => {})
+    }
     set({ activePending: null, suspended: null })
     void import('@renderer/lib/extension-ui-channel').then((m) => m.clearExtensionDialogDedupe())
   },

--- a/src/renderer/src/stores/ui-store-types.ts
+++ b/src/renderer/src/stores/ui-store-types.ts
@@ -197,6 +197,8 @@ export interface UIState {
   /** sessionFile → running (sidebar spinner) */
   sessionRuntimeRunning: Record<string, boolean>
   setSessionRuntimeRunning: (sessionFile: string, running: boolean) => void
+  /** Clear stale optimistic send/stream markers (used when the bound worker is provably idle). */
+  reconcileIdleMarkers: () => void
   /**
    * Session-scoped tool row expand memory (toolCallId → expanded).
    * Display-only; not persisted across app restarts.

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -334,6 +334,12 @@ export const useUIStore = create<UIState>()(
       else delete next[key]
       return { sessionRuntimeRunning: next }
     }),
+  reconcileIdleMarkers: () =>
+    set({
+      streamingAssistantId: null,
+      optimisticPendingUserText: null,
+      agentTurnBootstrapping: false,
+    }),
   lastModel: null,
   lastThinking: null,
   rememberModel: (model) => set({ lastModel: model }),

--- a/src/worker/desktop-ui-bridge.ts
+++ b/src/worker/desktop-ui-bridge.ts
@@ -23,6 +23,8 @@ type Pending = {
 export type DesktopUIBridge = {
   uiContext: Record<string, unknown>
   handleExtensionUIResponse: (response: ExtensionUIResponse) => void
+  /** Resolve a pending dialog as cancelled (renderer cleared it without a response). */
+  handleExtensionUiCancel: (cancel: { id?: string; reason?: string }) => void
   /** Cache interact args extracted by Worker (driven by adapter.json interact.fields). */
   setInteractArgs: (schema: 'questions' | 'review' | 'clarify', args: Record<string, unknown> | null) => void
   dispose: () => void
@@ -66,6 +68,24 @@ function createDialogPromise<T>(
         opts?.onDismiss?.(id, 'timeout')
         resolve(defaultValue)
       }, opts.timeout)
+    } else if (request.method !== 'notify') {
+      // Fallback timeout: a dialog that never gets a response (renderer cleared it,
+      // response routed to the wrong slot, window closed...) must not hang the turn forever.
+      timeoutId = setTimeout(() => {
+        cleanup()
+        opts?.onDismiss?.(id, 'timeout')
+        try {
+          emit({
+            id: randomUUID(),
+            method: 'notify',
+            notifyType: 'warning',
+            message: 'Dialog wait timed out after 5 minutes; auto-cancelled, conversation can continue',
+          })
+        } catch {
+          /* ignore */
+        }
+        resolve(defaultValue)
+      }, 5 * 60 * 1000)
     }
     pending.set(id, {
       resolve: (v) => resolve(parse(v as ExtensionUIResponse)),
@@ -251,6 +271,12 @@ export function createDesktopUIBridge(
 
   return {
     uiContext,
+    handleExtensionUiCancel(cancel: { id?: string; reason?: string }) {
+      const p = cancel?.id ? pending.get(cancel.id) : undefined
+      if (!p) return
+      p.cleanup()
+      p.resolve({ cancelled: true })
+    },
     handleExtensionUIResponse(response: ExtensionUIResponse) {
       const p = pending.get(response.id)
       if (!p) return

--- a/src/worker/handlers/worker-handlers-turn.ts
+++ b/src/worker/handlers/worker-handlers-turn.ts
@@ -180,6 +180,13 @@ export async function handleExtensionUiResponse(msg: WorkerIncomingMessage, repl
 }
 
 
+export async function handleExtensionUiCancel(msg: WorkerIncomingMessage, reply: WorkerReply): Promise<void> {
+        st.uiBridge?.handleExtensionUiCancel?.(msg.cancel as { id?: string; reason?: string })
+        reply({ type: 'extension-ui-cancel-done' })
+        return
+}
+
+
 export async function handleDispose(msg: WorkerIncomingMessage, reply: WorkerReply): Promise<void> {
         st.uiBridge?.dispose()
         st.uiBridge = null

--- a/src/worker/worker-port-handlers.ts
+++ b/src/worker/worker-port-handlers.ts
@@ -13,6 +13,7 @@ const dispatch: Record<string, (msg: WorkerIncomingMessage, reply: WorkerReply) 
   'followUp': Turn.handleFollowup,
   'clearQueue': Turn.handleClearqueue,
   'extension-ui-response': Turn.handleExtensionUiResponse,
+  'extension-ui-cancel': Turn.handleExtensionUiCancel,
   'dispose': Turn.handleDispose,
   'ping': Turn.handlePing,
   'setModel': Session.handleSetmodel,


### PR DESCRIPTION
# Bug 1: 回复完成后发送框仍显示「对话持续」

**Bug**：AI 回复完成后，Composer 仍显示「对话持续」/运行状态不消失，切换会话后残留无法自愈。

**原因**：乐观发送标记（`streamingAssistantId` / `optimisticPendingUserText` / `agentTurnBootstrapping`）在切换会话期间残留，upstream 无轮询对账（reconcile）机制。

**复现**：发送消息 → 回复中切走 → 切回 → 发送框仍显示对话持续（worker 已空闲）。

**修复方式**：
- `ui-store.ts` 新增 `reconcileIdleMarkers` action（清三个乐观标记）；
- `session-worker-sync.ts` 轮询对账：绑定快照非 running 且绑定视图会话时执行 `reconcileIdleMarkers` + `setSessionRuntimeRunning(false)`。

---

# Bug 2: ask_user_question 弹窗偶发不弹 + 应答后对话卡死

**Bug**：扩展/agent 调用 ask_user_question 时弹窗偶发不出现；应答后对话卡死。

**原因**（4 因子）：
1. main 前台门控丢弃非前台 slot 的 extension-ui-request；
2. `respondExtensionUI` 只发 foregroundSlot，无来源登记，应答发错 slot；
3. renderer 清理不同步（无 cancel 消息，worker 侧 promise 悬挂）；
4. `createDialogPromise` 无默认超时兜底（默认永不超时）。

**复现**：多会话并行时，非前台会话 agent 调用 ask_user_question（偶发不弹）；弹窗应答后 worker 卡死。

**修复方式**：
- `worker-manager-pool.ts`：转发放开前台门控（保留 notify 门控语义）+ 模块级 `extensionUiDialogSource` Map（id→poolKey）来源登记；dismiss 放开并清理登记；
- `worker-manager.ts`：`respondExtensionUI` 按来源路由（缺失/stopping 回退 foreground）；新增 `cancelExtensionUI`；
- `desktop-ui-bridge.ts`：`handleExtensionUiCancel`；`createDialogPromise` 默认 5min 超时兜底（notify 除外）；
- worker 消息层：新增 `extension-ui-cancel` handler + dispatch 注册；
- IPC/preload：新增 `ipc:extension.cancelUI` handler + 白名单；
- `extension-ui-store.ts`：清理前先发 cancelUI 通知 worker。

---

# Bug 3: 新建对话跳到最近活跃会话（占位态缺陷）

**Bug**：点击「新会话」后，旧会话事件画进空白 timeline（视图跳到最近活跃会话）。

**原因**：`resolveAppEventRoute` 占位态（viewFile=null）命中 `workerFile==evFile → visible` 分支；`workerLiveSnapshot` 未清，残留快照把旧会话事件误判为可见。

**复现**：侧栏新建对话 → 后台 worker 事件回流 → 占位态 timeline 被旧会话事件填充。

**修复方式**：
- `apply-app-event-route.ts`：viewFile 为空且 viewSid 为空或 `__pending_new__`（占位态/Home）时，所有事件短路 `background`；
- `project-sidebar.tsx`：`handleNewSessionInProject` 清 `workerLiveSnapshot`（null/null/idle）。
