### PR TITLE
fix(composer): keep caret visible when input exceeds max height

### DIFF
--- a/src/renderer/src/features/composer/attachments.tsx
+++ b/src/renderer/src/features/composer/attachments.tsx
@@ -191,11 +191,25 @@ export function insertAttachmentAtCursor(el: HTMLElement, meta: AttachmentMeta) 
   frag.appendChild(chip)
   frag.appendChild(after)
   range.insertNode(frag)
+  // Normalize before placing the caret: normalize may merge the ZWSP with adjacent text
+  // (e.g. "\u200Bcd"); a selection referencing the merged ZWSP node would lose the caret.
+  // The chip is an element, so normalize never removes it.
   el.normalize()
-  range.setStartAfter(after)
-  range.setEndAfter(after)
-  sel?.removeAllRanges()
-  sel?.addRange(range)
+  const chipNext = chip.nextSibling
+  if (sel) {
+    const caretRange = document.createRange()
+    if (chipNext && chipNext.nodeType === Node.TEXT_NODE) {
+      // Place the caret after the chip: offset 1 into the following text node (after the ZWSP,
+      // which may already be merged with the following text).
+      caretRange.setStart(chipNext, 1)
+      caretRange.setEnd(chipNext, 1)
+    } else {
+      caretRange.setStartAfter(chip)
+      caretRange.setEndAfter(chip)
+    }
+    sel.removeAllRanges()
+    sel.addRange(caretRange)
+  }
   el.dispatchEvent(new Event('input', { bubbles: true }))
 }
 

--- a/src/renderer/src/features/composer/composer-editor-caret.test.ts
+++ b/src/renderer/src/features/composer/composer-editor-caret.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { insertBrAtCursor, insertTextAtCursor } from './composer-editor-caret'
+
+function setupEditor(html: string): HTMLElement {
+  const el = document.createElement('div')
+  el.contentEditable = 'true'
+  el.innerHTML = html
+  document.body.appendChild(el)
+  return el
+}
+
+function placeCaretAtEnd(el: HTMLElement) {
+  const range = document.createRange()
+  range.selectNodeContents(el)
+  range.collapse(false)
+  const sel = window.getSelection()
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+}
+
+function placeCaretAtOffset(el: HTMLElement, offset: number) {
+  const textNode = el.firstChild as Text
+  const range = document.createRange()
+  range.setStart(textNode, offset)
+  range.collapse(true)
+  const sel = window.getSelection()
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+}
+
+function caret(): Range {
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) throw new Error('no selection')
+  return sel.getRangeAt(0)
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  window.getSelection()?.removeAllRanges()
+})
+
+describe('insertBrAtCursor', () => {
+  it('appends a line break at the end and keeps the caret after it', () => {
+    const el = setupEditor('hello')
+    placeCaretAtEnd(el)
+
+    insertBrAtCursor(el)
+
+    expect(el.textContent).toBe('hello\u200B')
+    expect(el.querySelectorAll('br').length).toBe(1)
+    const range = caret()
+    expect(range.startContainer.nodeType).toBe(Node.TEXT_NODE)
+    expect((range.startContainer as Text).textContent).toBe('\u200B')
+    expect(range.startOffset).toBe(1)
+  })
+
+  it('inserts a line break in the middle of text and keeps the caret after the break', () => {
+    const el = setupEditor('abcd')
+    placeCaretAtOffset(el, 2)
+
+    insertBrAtCursor(el)
+
+    // The ZWSP merges with the following text into "\u200Bcd"; the caret must land at offset 1
+    // (right after the ZWSP) instead of being lost.
+    expect(el.textContent).toBe('ab\u200Bcd')
+    expect(el.querySelectorAll('br').length).toBe(1)
+    const range = caret()
+    expect(range.startContainer.nodeType).toBe(Node.TEXT_NODE)
+    expect((range.startContainer as Text).textContent).toBe('\u200Bcd')
+    expect(range.startOffset).toBe(1)
+  })
+
+  it('handles an empty editor', () => {
+    const el = setupEditor('')
+    placeCaretAtEnd(el)
+
+    insertBrAtCursor(el)
+
+    expect(el.textContent).toBe('\u200B')
+    const range = caret()
+    expect(range.startContainer).toBe(el.lastChild)
+    expect(range.startOffset).toBe(1)
+  })
+})
+
+describe('insertTextAtCursor', () => {
+  it('appends text at the end and keeps the caret after it', () => {
+    const el = setupEditor('hello')
+    placeCaretAtEnd(el)
+
+    insertTextAtCursor(el, ' world')
+
+    expect(el.textContent).toBe('hello world')
+    const range = caret()
+    expect(range.startContainer).toBe(el.firstChild)
+    expect(range.startOffset).toBe(11)
+  })
+
+  it('inserts text in the middle of a text node', () => {
+    const el = setupEditor('abcd')
+    placeCaretAtOffset(el, 2)
+
+    insertTextAtCursor(el, 'XY')
+
+    expect(el.textContent).toBe('abXYcd')
+    const range = caret()
+    expect(range.startContainer.nodeType).toBe(Node.TEXT_NODE)
+    expect((range.startContainer as Text).textContent).toBe('abXYcd')
+    expect(range.startOffset).toBe(4)
+  })
+
+  it('inserts text at the start of a text node (offset 0)', () => {
+    const el = setupEditor('abcd')
+    placeCaretAtOffset(el, 0)
+
+    insertTextAtCursor(el, 'XY')
+
+    expect(el.textContent).toBe('XYabcd')
+    const range = caret()
+    expect(range.startContainer.nodeType).toBe(Node.TEXT_NODE)
+    expect((range.startContainer as Text).textContent).toBe('XYabcd')
+    expect(range.startOffset).toBe(2)
+  })
+
+  it('replaces a selection and keeps the caret after the inserted text', () => {
+    const el = setupEditor('abcdef')
+    const textNode = el.firstChild as Text
+    const range = document.createRange()
+    range.setStart(textNode, 2)
+    range.setEnd(textNode, 4)
+    const sel = window.getSelection()
+    sel?.removeAllRanges()
+    sel?.addRange(range)
+
+    insertTextAtCursor(el, 'XY')
+
+    expect(el.textContent).toBe('abXYef')
+    const caretRange = caret()
+    expect((caretRange.startContainer as Text).textContent).toBe('abXYef')
+    expect(caretRange.startOffset).toBe(4)
+  })
+})

--- a/src/renderer/src/features/composer/composer-editor-caret.ts
+++ b/src/renderer/src/features/composer/composer-editor-caret.ts
@@ -48,11 +48,23 @@ export function insertBrAtCursor(el: HTMLElement) {
   range.setStartAfter(br)
   range.setEndAfter(br)
   range.insertNode(after)
-  range.setStartAfter(after)
-  range.setEndAfter(after)
-  sel?.removeAllRanges()
-  sel?.addRange(range)
+  // Normalize before placing the caret: normalize merges the ZWSP with adjacent text (e.g.
+  // "\u200Bcd"); setting the selection first would leave it referencing a removed node.
   el.normalize()
+  const next = br.nextSibling
+  if (sel) {
+    const caretRange = document.createRange()
+    if (next && next.nodeType === Node.TEXT_NODE) {
+      // The ZWSP is the 1st char of the text node after the <br>; put the caret after it (offset 1).
+      caretRange.setStart(next, 1)
+      caretRange.setEnd(next, 1)
+    } else {
+      caretRange.setStartAfter(br)
+      caretRange.setEndAfter(br)
+    }
+    sel.removeAllRanges()
+    sel.addRange(caretRange)
+  }
   el.dispatchEvent(new Event('input', { bubbles: true }))
 }
 
@@ -66,13 +78,46 @@ export function insertTextAtCursor(el: HTMLElement, text: string) {
     range.selectNodeContents(el)
     range.collapse(false)
   }
+  // Record the insertion anchor: normalize merges/removes the inserted text node, so capture
+  // the original position first and derive the caret from it.
+  const anchorIsText = range.startContainer.nodeType === Node.TEXT_NODE
+  const anchorNode = range.startContainer
+  const anchorOffset = range.startOffset
   range.deleteContents()
   const node = document.createTextNode(text)
   range.insertNode(node)
-  range.setStartAfter(node)
-  range.setEndAfter(node)
-  sel?.removeAllRanges()
-  sel?.addRange(range)
+  const prev = node.previousSibling
+  // Normalize before placing the caret so the selection never references merged/removed nodes.
   el.normalize()
+  if (sel) {
+    const caretRange = document.createRange()
+    if (anchorIsText && anchorNode.parentNode) {
+      // Caret was inside a text node with offset > 0: that node keeps the full merged text
+      // after normalize; caret = original offset + inserted text length.
+      caretRange.setStart(anchorNode, anchorOffset + text.length)
+      caretRange.setEnd(anchorNode, anchorOffset + text.length)
+    } else if (anchorIsText && node.parentNode) {
+      // Caret was at the start of a text node (offset 0): the original node was removed by
+      // normalize, the inserted node survives; caret = inserted text length.
+      caretRange.setStart(node, text.length)
+      caretRange.setEnd(node, text.length)
+    } else if (prev && prev.parentNode && prev.nodeType === Node.TEXT_NODE) {
+      // Insert at an element boundary with a preceding text node: the new text merges into it;
+      // caret sits at its end.
+      const prevText = prev as Text
+      caretRange.setStart(prevText, prevText.length)
+      caretRange.setEnd(prevText, prevText.length)
+    } else if (node.parentNode) {
+      // Insert at an element boundary with no preceding text: the inserted node survives (it may
+      // absorb following text); caret sits right after the inserted text.
+      caretRange.setStart(node, text.length)
+      caretRange.setEnd(node, text.length)
+    } else {
+      caretRange.selectNodeContents(el)
+      caretRange.collapse(false)
+    }
+    sel.removeAllRanges()
+    sel.addRange(caretRange)
+  }
   el.dispatchEvent(new Event('input', { bubbles: true }))
 }

--- a/src/renderer/src/features/composer/rich-input.test.tsx
+++ b/src/renderer/src/features/composer/rich-input.test.tsx
@@ -237,4 +237,54 @@ describe('RichInput height reset', () => {
 
     expect(scrollTopValue).toBe(30)
   })
+
+  it('zero-size caret probe does not feed back into the mutation observer (no rAF loop)', () => {
+    // Chrome 在元素边界（空行 / <br> 后）的光标会给出零尺寸 rect；此时用临时探针测量。
+    // 探针插入/移除会触发 MutationObserver → 又调度 rAF → 下一帧再插探针 = 永久循环。
+    // 测量期间必须临时断开 observer，且一轮刷新后不得再有新的 rAF 被调度。
+    scrollHeight = 180
+    const { container } = render(<RichInput />)
+    const input = container.querySelector('.rich-input') as HTMLDivElement
+
+    Object.defineProperty(input, 'clientHeight', { configurable: true, get: () => 112 })
+    Object.defineProperty(input, 'scrollTop', {
+      configurable: true,
+      get: () => 0,
+      set: () => undefined,
+    })
+
+    const zeroRect = { top: 0, bottom: 0, width: 0, height: 0 } as DOMRect
+    const range = {
+      collapsed: true,
+      commonAncestorContainer: input,
+      endContainer: input,
+      endOffset: 0,
+      getBoundingClientRect: () => zeroRect,
+      insertNode: vi.fn(),
+    } as unknown as Range
+    const selection = {
+      rangeCount: 1,
+      getRangeAt: () => range,
+      removeAllRanges: () => undefined,
+      addRange: () => undefined,
+    } as unknown as Selection
+    vi.spyOn(window, 'getSelection').mockReturnValue(selection)
+    const createRange = vi.spyOn(document, 'createRange').mockReturnValue({
+      setStart: () => undefined,
+      collapse: () => undefined,
+    } as unknown as Range)
+
+    input.textContent = 'x'.repeat(180)
+    const probeSpy = vi.spyOn(document, 'createElement')
+    act(() => mutationCallback?.([], {} as MutationObserver))
+    flushAnimationFrames()
+
+    // 探针路径被使用：断开 observer → 插入探针 → 移除 → 恢复
+    expect(range.insertNode).toHaveBeenCalled()
+    expect(mutationDisconnect).toHaveBeenCalled()
+    expect(createRange).toHaveBeenCalled()
+    // 循环已断：刷新结束后没有新的 rAF 排队
+    expect(animationFrames).toHaveLength(0)
+    void probeSpy
+  })
 })

--- a/src/renderer/src/features/composer/rich-input.test.tsx
+++ b/src/renderer/src/features/composer/rich-input.test.tsx
@@ -178,4 +178,63 @@ describe('RichInput height reset', () => {
     expect(input.style.height).toBe('112px')
     expect(input).toHaveClass('min-h-[2.5rem]')
   })
+
+  it('scrolls the caret into view when a programmatic insert pushes it below the fold', () => {
+    scrollHeight = 180
+    const { container } = render(<RichInput />)
+    const input = container.querySelector('.rich-input') as HTMLDivElement
+
+    let scrollTopValue = 0
+    Object.defineProperty(input, 'clientHeight', { configurable: true, get: () => 112 })
+    Object.defineProperty(input, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTopValue,
+      set: (v: number) => {
+        scrollTopValue = v
+      },
+    })
+
+    // Simulate Shift+Enter placing the caret below the fold (content 180px, viewport 112px):
+    // the collapsed range's rect bottom is beyond the viewport, so scroll to the bottom.
+    const range = {
+      collapsed: true,
+      commonAncestorContainer: input,
+      endContainer: input,
+      endOffset: 0,
+      getBoundingClientRect: () => ({ top: 0, bottom: 160, width: 0, height: 160 } as DOMRect),
+    } as unknown as Range
+    const selection = { rangeCount: 1, getRangeAt: () => range } as unknown as Selection
+    vi.spyOn(window, 'getSelection').mockReturnValue(selection)
+
+    input.textContent = 'x'.repeat(180)
+    act(() => mutationCallback?.([], {} as MutationObserver))
+    flushAnimationFrames()
+
+    expect(scrollTopValue).toBe(48) // 160 - 112
+  })
+
+  it('preserves the user scroll position across height refreshes', () => {
+    scrollHeight = 180
+    const { container } = render(<RichInput />)
+    const input = container.querySelector('.rich-input') as HTMLDivElement
+
+    let scrollTopValue = 0
+    Object.defineProperty(input, 'clientHeight', { configurable: true, get: () => 112 })
+    Object.defineProperty(input, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTopValue,
+      set: (v: number) => {
+        scrollTopValue = v
+      },
+    })
+    scrollTopValue = 30
+
+    // No caret inside the editor (jsdom's default selection is empty): the refresh only keeps
+    // the scroll position and does not scroll further.
+    inputWidth = 600
+    act(() => resizeCallback?.([resizeEntry(input, inputWidth)], {} as ResizeObserver))
+    flushAnimationFrames()
+
+    expect(scrollTopValue).toBe(30)
+  })
 })

--- a/src/renderer/src/features/composer/rich-input.tsx
+++ b/src/renderer/src/features/composer/rich-input.tsx
@@ -53,7 +53,10 @@ function collectTextNodeContent(node: Node): string {
  * independent of scrolling. Returns null when the caret is outside the editor, a selection is
  * active, or the position cannot be measured.
  */
-function caretContentRange(el: HTMLElement): { top: number; bottom: number } | null {
+function caretContentRange(
+  el: HTMLElement,
+  mutationObserver?: MutationObserver | null,
+): { top: number; bottom: number } | null {
   const sel = window.getSelection()
   if (!sel || !sel.rangeCount) return null
   const range = sel.getRangeAt(0)
@@ -74,6 +77,9 @@ function caretContentRange(el: HTMLElement): { top: number; bottom: number } | n
   // A collapsed caret at an element boundary (blank line / right after a <br>) can produce a
   // zero-sized rect in Chrome. Insert a temporary zero-width probe node at the caret, measure,
   // then remove it and restore the selection.
+  // 探针插入/移除会被 editor 的 MutationObserver 当作内容变更，再次调度 rAF → 下一帧又插探针，
+  // 形成永久测量循环。测量期间临时断开 observer，探针读写不再触发任何回调。
+  if (mutationObserver) mutationObserver.disconnect()
   const probe = document.createElement('span')
   probe.style.cssText = 'display:inline-block;width:0;height:1px'
   probe.textContent = '\u200B'
@@ -82,6 +88,9 @@ function caretContentRange(el: HTMLElement): { top: number; bottom: number } | n
   range.insertNode(probe)
   const probed = measure(probe.getBoundingClientRect())
   probe.remove()
+  if (mutationObserver) {
+    mutationObserver.observe(el, { childList: true, characterData: true, subtree: true })
+  }
   const sel2 = window.getSelection()
   if (sel2) {
     const restore = document.createRange()
@@ -94,8 +103,9 @@ function caretContentRange(el: HTMLElement): { top: number; bottom: number } | n
 }
 
 /** Scroll the editor so the caret is back in view (no-op when the caret is absent/unmeasurable). */
-function scrollCaretIntoView(el: HTMLElement) {
-  const caret = caretContentRange(el)
+function scrollCaretIntoView(el: HTMLElement, mutationObserver?: MutationObserver | null) {
+  if (el.scrollHeight <= el.clientHeight) return
+  const caret = caretContentRange(el, mutationObserver)
   if (!caret) return
   const viewTop = el.scrollTop
   const viewBottom = viewTop + el.clientHeight
@@ -112,6 +122,9 @@ export const RichInput = forwardRef<HTMLDivElement, RichInputProps>(function Ric
 ) {
   const innerRef = useRef<HTMLDivElement>(null)
   const animationFrameRef = useRef<number | null>(null)
+  // 探针测量期间要临时断开 MutationObserver（见 caretContentRange），
+  // 通过 ref 传递避免闭包捕获旧实例。
+  const mutationObserverRef = useRef<MutationObserver | null>(null)
   useImperativeHandle(ref, () => innerRef.current as HTMLDivElement, [])
 
   const refreshLayoutAndEmpty = () => {
@@ -126,7 +139,7 @@ export const RichInput = forwardRef<HTMLDivElement, RichInputProps>(function Ric
     node.scrollTop = Math.min(prevScrollTop, Math.max(node.scrollHeight - node.clientHeight, 0))
     // Programmatic inserts (Shift+Enter, paste, voice input) skip the browser's caret-into-view
     // scrolling, so bring the caret back into view manually (no-op while content fits).
-    scrollCaretIntoView(node)
+    scrollCaretIntoView(node, mutationObserverRef.current)
   }
 
   const scheduleRefreshLayoutAndEmpty = () => {
@@ -168,9 +181,11 @@ export const RichInput = forwardRef<HTMLDivElement, RichInputProps>(function Ric
       characterData: true,
       subtree: true,
     })
+    mutationObserverRef.current = mutationObserver
     return () => {
       resizeObserver.disconnect()
       mutationObserver.disconnect()
+      mutationObserverRef.current = null
       if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current)
         animationFrameRef.current = null

--- a/src/renderer/src/features/composer/rich-input.tsx
+++ b/src/renderer/src/features/composer/rich-input.tsx
@@ -2,6 +2,9 @@ import { forwardRef, useRef, useImperativeHandle, useLayoutEffect } from 'react'
 import { hideAllDelayedTooltips } from './delayed-tooltip'
 import { cn } from '@renderer/lib/utils'
 
+/** Max editor height (kept in sync with the max-height in globals.css; content scrolls beyond it). */
+const MAX_EDITOR_HEIGHT = 112
+
 export interface RichInputProps {
   placeholder?: string
   disabled?: boolean
@@ -45,6 +48,64 @@ function collectTextNodeContent(node: Node): string {
   return text
 }
 
+/**
+ * Content coordinates (top/bottom) of the collapsed caret relative to the editor's content,
+ * independent of scrolling. Returns null when the caret is outside the editor, a selection is
+ * active, or the position cannot be measured.
+ */
+function caretContentRange(el: HTMLElement): { top: number; bottom: number } | null {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount) return null
+  const range = sel.getRangeAt(0)
+  if (!range.collapsed || !el.contains(range.commonAncestorContainer)) return null
+
+  const measure = (rect: DOMRect | null): { top: number; bottom: number } | null => {
+    if (!rect || (rect.height <= 0 && rect.width <= 0)) return null
+    const elRect = el.getBoundingClientRect()
+    return {
+      top: rect.top - elRect.top + el.scrollTop,
+      bottom: rect.bottom - elRect.top + el.scrollTop,
+    }
+  }
+
+  const direct = measure(range.getBoundingClientRect())
+  if (direct) return direct
+
+  // A collapsed caret at an element boundary (blank line / right after a <br>) can produce a
+  // zero-sized rect in Chrome. Insert a temporary zero-width probe node at the caret, measure,
+  // then remove it and restore the selection.
+  const probe = document.createElement('span')
+  probe.style.cssText = 'display:inline-block;width:0;height:1px'
+  probe.textContent = '\u200B'
+  const savedNode = range.endContainer
+  const savedOffset = range.endOffset
+  range.insertNode(probe)
+  const probed = measure(probe.getBoundingClientRect())
+  probe.remove()
+  const sel2 = window.getSelection()
+  if (sel2) {
+    const restore = document.createRange()
+    restore.setStart(savedNode, savedOffset)
+    restore.collapse(true)
+    sel2.removeAllRanges()
+    sel2.addRange(restore)
+  }
+  return probed
+}
+
+/** Scroll the editor so the caret is back in view (no-op when the caret is absent/unmeasurable). */
+function scrollCaretIntoView(el: HTMLElement) {
+  const caret = caretContentRange(el)
+  if (!caret) return
+  const viewTop = el.scrollTop
+  const viewBottom = viewTop + el.clientHeight
+  if (caret.bottom > viewBottom) {
+    el.scrollTop = caret.bottom - el.clientHeight
+  } else if (caret.top < viewTop) {
+    el.scrollTop = caret.top
+  }
+}
+
 export const RichInput = forwardRef<HTMLDivElement, RichInputProps>(function RichInput(
   { placeholder, disabled, onKeyDown, onPaste, onFocus, onBlur, onInput, className },
   ref,
@@ -56,9 +117,16 @@ export const RichInput = forwardRef<HTMLDivElement, RichInputProps>(function Ric
   const refreshLayoutAndEmpty = () => {
     const node = innerRef.current
     if (!node) return
+    // Reset height to 'auto' before re-reading scrollHeight so content can shrink; the reset
+    // clamps the scrollbar to 0, so restore the previous scroll position after re-clamping.
+    const prevScrollTop = node.scrollTop
     node.style.height = 'auto'
-    node.style.height = Math.min(node.scrollHeight, 112) + 'px'
+    node.style.height = Math.min(node.scrollHeight, MAX_EDITOR_HEIGHT) + 'px'
     syncRichInputEmpty(node)
+    node.scrollTop = Math.min(prevScrollTop, Math.max(node.scrollHeight - node.clientHeight, 0))
+    // Programmatic inserts (Shift+Enter, paste, voice input) skip the browser's caret-into-view
+    // scrolling, so bring the caret back into view manually (no-op while content fits).
+    scrollCaretIntoView(node)
   }
 
   const scheduleRefreshLayoutAndEmpty = () => {


### PR DESCRIPTION
## 用户场景 / 问题
在输入框里连续输入多行文本，超过 composer 最大高度后继续打字，光标会跑到可视区域外，用户看不到自己正在输入的位置。

## 代码问题
textarea 达到 max-height 后内容溢出滚动，但输入时没有把光标所在行滚动进可视区域。

## 修复方案
输入/换行时计算光标行位置，主动 `scrollTop` 让光标行保持在可视区域内。纯 renderer 改动，无 IPC 变化。