### PR TITLE
fix(layout): adapt panel widths when the window is resized

### DIFF
--- a/src/renderer/src/components/app/main-layout-shell.test.tsx
+++ b/src/renderer/src/components/app/main-layout-shell.test.tsx
@@ -1,0 +1,75 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { MainLayoutShell } from './main-layout-shell'
+import { useUIStore } from '@renderer/stores/ui-store'
+
+const DEFAULTS = {
+  sidebarWidth: 260,
+  sidebarCollapsed: false,
+  rightPanelWidth: 288,
+  rightPanelCollapsed: false,
+}
+
+beforeEach(() => {
+  useUIStore.setState(DEFAULTS)
+})
+
+afterEach(() => {
+  useUIStore.setState(DEFAULTS)
+})
+
+function resizeWindow(width: number) {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: width })
+  act(() => {
+    window.dispatchEvent(new Event('resize'))
+  })
+}
+
+describe('MainLayoutShell window-resize adaptation', () => {
+  it('clamps both panels when the window shrinks so the center column keeps a gap', () => {
+    render(<MainLayoutShell left={<div />} center={<div />} right={<div />} />)
+    useUIStore.setState({ sidebarWidth: 360, rightPanelWidth: 500 })
+
+    resizeWindow(700)
+
+    const s = useUIStore.getState()
+    // Sidebar capped at 40% of the window.
+    expect(s.sidebarWidth).toBe(280)
+    // Right panel capped so the center keeps 120px: 700 - 280 - 120 = 300.
+    expect(s.rightPanelWidth).toBe(300)
+  })
+
+  it('keeps panel widths when the window grows', () => {
+    render(<MainLayoutShell left={<div />} center={<div />} right={<div />} />)
+    useUIStore.setState({ sidebarWidth: 260, rightPanelWidth: 288 })
+
+    resizeWindow(1800)
+
+    const s = useUIStore.getState()
+    expect(s.sidebarWidth).toBe(260)
+    expect(s.rightPanelWidth).toBe(288)
+  })
+
+  it('does not touch the sidebar width while it is collapsed', () => {
+    render(<MainLayoutShell left={<div />} center={<div />} right={<div />} />)
+    useUIStore.setState({ sidebarWidth: 360, sidebarCollapsed: true, rightPanelWidth: 500 })
+
+    resizeWindow(700)
+
+    const s = useUIStore.getState()
+    expect(s.sidebarWidth).toBe(360)
+    // Right clamp accounts for the 40px collapsed rail: 700 - 40 - 120 = 540 fits 500.
+    expect(s.rightPanelWidth).toBe(500)
+  })
+
+  it('adapts persisted oversized widths on mount', () => {
+    useUIStore.setState({ sidebarWidth: 360, rightPanelWidth: 500 })
+    // The mount-time clamp uses the current window size without needing a resize event.
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 640 })
+    render(<MainLayoutShell left={<div />} center={<div />} right={<div />} />)
+
+    const s = useUIStore.getState()
+    expect(s.sidebarWidth).toBe(256) // 40% of 640
+    expect(s.rightPanelWidth).toBe(280) // 640 - 256 - 120 = 264 → clamped to min 280
+  })
+})

--- a/src/renderer/src/components/app/main-layout-shell.test.tsx
+++ b/src/renderer/src/components/app/main-layout-shell.test.tsx
@@ -25,18 +25,24 @@ function resizeWindow(width: number) {
   })
 }
 
+function gridColumns(): string {
+  const shell = document.querySelector('.shell-three-col') as HTMLElement | null
+  return shell?.style.gridTemplateColumns || ''
+}
+
 describe('MainLayoutShell window-resize adaptation', () => {
-  it('clamps both panels when the window shrinks so the center column keeps a gap', () => {
+  it('clamps both panels in the rendered grid when the window shrinks, without overwriting persisted widths', () => {
     render(<MainLayoutShell left={<div />} center={<div />} right={<div />} />)
     useUIStore.setState({ sidebarWidth: 360, rightPanelWidth: 500 })
 
     resizeWindow(700)
 
+    // 持久化首选宽度保持原样：缩小窗口不得永久覆盖用户设置
     const s = useUIStore.getState()
-    // Sidebar capped at 40% of the window.
-    expect(s.sidebarWidth).toBe(280)
-    // Right panel capped so the center keeps 120px: 700 - 280 - 120 = 300.
-    expect(s.rightPanelWidth).toBe(300)
+    expect(s.sidebarWidth).toBe(360)
+    expect(s.rightPanelWidth).toBe(500)
+    // 展示值按当前窗口 clamp：侧栏 ≤40%（280），右栏 ≤ 700-280-120=300
+    expect(gridColumns()).toBe('280px minmax(0, 1fr) 300px')
   })
 
   it('keeps panel widths when the window grows', () => {
@@ -48,6 +54,7 @@ describe('MainLayoutShell window-resize adaptation', () => {
     const s = useUIStore.getState()
     expect(s.sidebarWidth).toBe(260)
     expect(s.rightPanelWidth).toBe(288)
+    expect(gridColumns()).toBe('260px minmax(0, 1fr) 288px')
   })
 
   it('does not touch the sidebar width while it is collapsed', () => {
@@ -58,18 +65,22 @@ describe('MainLayoutShell window-resize adaptation', () => {
 
     const s = useUIStore.getState()
     expect(s.sidebarWidth).toBe(360)
-    // Right clamp accounts for the 40px collapsed rail: 700 - 40 - 120 = 540 fits 500.
     expect(s.rightPanelWidth).toBe(500)
+    // 收起侧栏走 40px rail：右栏 500 放得下 → 展示不变
+    expect(gridColumns()).toBe('0px minmax(0, 1fr) 500px')
   })
 
-  it('adapts persisted oversized widths on mount', () => {
+  it('adapts persisted oversized widths on mount without writing them back', () => {
     useUIStore.setState({ sidebarWidth: 360, rightPanelWidth: 500 })
-    // The mount-time clamp uses the current window size without needing a resize event.
+    // 挂载时按当前窗口 clamp（无需 resize 事件）
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 640 })
     render(<MainLayoutShell left={<div />} center={<div />} right={<div />} />)
 
     const s = useUIStore.getState()
-    expect(s.sidebarWidth).toBe(256) // 40% of 640
-    expect(s.rightPanelWidth).toBe(280) // 640 - 256 - 120 = 264 → clamped to min 280
+    // 持久化值未被改写
+    expect(s.sidebarWidth).toBe(360)
+    expect(s.rightPanelWidth).toBe(500)
+    // 展示 clamp：侧栏 40% of 640 = 256；右栏 640-256-120=264 → 最小值 280
+    expect(gridColumns()).toBe('256px minmax(0, 1fr) 280px')
   })
 })

--- a/src/renderer/src/components/app/main-layout-shell.tsx
+++ b/src/renderer/src/components/app/main-layout-shell.tsx
@@ -7,6 +7,13 @@ import { RightPanelCollapsedRail } from '@renderer/components/app/right-panel-co
 /** Collapsed right rail width — keep in sync with RightPanelCollapsedRail (w-10 = 40px) */
 const RIGHT_COLLAPSED_RAIL_PX = 40
 
+/** Minimum width the center column keeps next to a panel while dragging / resizing the window. */
+const MIN_CENTER_GAP = 120
+
+/** Minimum panel widths (mirror the clamps in ui-store-shell-slice). */
+const MIN_SIDEBAR_PX = 200
+const MIN_RIGHT_PANEL_PX = 280
+
 /**
  * 三栏 Grid：侧栏用 0fr ↔ 固定宽 过渡，中间列 1fr 由浏览器插值，避免 width 动画每帧重排 Timeline。
  * Cursor UI 实验：右栏收起时保留窄 icon rail（状态点 + 面板入口），不完全消失。
@@ -39,9 +46,8 @@ export function MainLayoutShell({
     const onMove = (e: MouseEvent) => {
       if (leftDragRef.current) setLeftWidth(e.clientX)
       if (rightDragRef.current) {
-        const minCenterGap = 120
         const leftColW = leftCollapsed ? RIGHT_COLLAPSED_RAIL_PX : leftWidth
-        const maxRight = Math.max(280, window.innerWidth - leftColW - minCenterGap)
+        const maxRight = Math.max(MIN_RIGHT_PANEL_PX, window.innerWidth - leftColW - MIN_CENTER_GAP)
         setRightWidth(Math.min(window.innerWidth - e.clientX, maxRight))
       }
     }
@@ -62,6 +68,29 @@ export function MainLayoutShell({
       window.removeEventListener('mouseup', onUp)
     }
   }, [setLeftWidth, setRightWidth, leftCollapsed, leftWidth])
+
+  // Adapt persisted panel widths when the window is resized: the columns are fixed px from the
+  // store, so without this they either overflow the window (center collapses to 0) on smaller
+  // windows or stay disproportionately small on larger ones.
+  useEffect(() => {
+    const onWindowResize = () => {
+      const { innerWidth } = window
+      const state = useUIStore.getState()
+      if (!state.sidebarCollapsed) {
+        // Cap the sidebar to 40% of the window so the center column stays usable.
+        const maxLeft = Math.max(MIN_SIDEBAR_PX, Math.round(innerWidth * 0.4))
+        if (state.sidebarWidth > maxLeft) state.setSidebarWidth(maxLeft)
+      }
+      const after = useUIStore.getState()
+      const leftColW = after.sidebarCollapsed ? RIGHT_COLLAPSED_RAIL_PX : after.sidebarWidth
+      const maxRight = Math.max(MIN_RIGHT_PANEL_PX, innerWidth - leftColW - MIN_CENTER_GAP)
+      if (after.rightPanelWidth > maxRight) after.setRightPanelWidth(maxRight)
+    }
+    window.addEventListener('resize', onWindowResize)
+    // Also clamp once on mount so oversized persisted widths adapt to the current window.
+    onWindowResize()
+    return () => window.removeEventListener('resize', onWindowResize)
+  }, [])
 
   const leftCol = leftCollapsed ? '0px' : `${leftWidth}px`
   const rightCol = rightCollapsed ? `${RIGHT_COLLAPSED_RAIL_PX}px` : `${rightWidth}px`

--- a/src/renderer/src/components/app/main-layout-shell.tsx
+++ b/src/renderer/src/components/app/main-layout-shell.tsx
@@ -72,28 +72,26 @@ export function MainLayoutShell({
   // Adapt persisted panel widths when the window is resized: the columns are fixed px from the
   // store, so without this they either overflow the window (center collapses to 0) on smaller
   // windows or stay disproportionately small on larger ones.
+  // 注意：窗口缩小只是“临时生效的展示值”，不得写回持久化首选宽度——否则缩小一次就永久
+  // 丢失用户设置（放大后无法恢复）。resize 只触发重渲染，实际 clamp 在渲染时实时计算。
+  const [windowWidth, setWindowWidth] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth : 0,
+  )
   useEffect(() => {
-    const onWindowResize = () => {
-      const { innerWidth } = window
-      const state = useUIStore.getState()
-      if (!state.sidebarCollapsed) {
-        // Cap the sidebar to 40% of the window so the center column stays usable.
-        const maxLeft = Math.max(MIN_SIDEBAR_PX, Math.round(innerWidth * 0.4))
-        if (state.sidebarWidth > maxLeft) state.setSidebarWidth(maxLeft)
-      }
-      const after = useUIStore.getState()
-      const leftColW = after.sidebarCollapsed ? RIGHT_COLLAPSED_RAIL_PX : after.sidebarWidth
-      const maxRight = Math.max(MIN_RIGHT_PANEL_PX, innerWidth - leftColW - MIN_CENTER_GAP)
-      if (after.rightPanelWidth > maxRight) after.setRightPanelWidth(maxRight)
-    }
+    const onWindowResize = () => setWindowWidth(window.innerWidth)
     window.addEventListener('resize', onWindowResize)
-    // Also clamp once on mount so oversized persisted widths adapt to the current window.
-    onWindowResize()
+    // 挂载时也触发一次，让超大的持久化宽度适配当前窗口
     return () => window.removeEventListener('resize', onWindowResize)
   }, [])
 
-  const leftCol = leftCollapsed ? '0px' : `${leftWidth}px`
-  const rightCol = rightCollapsed ? `${RIGHT_COLLAPSED_RAIL_PX}px` : `${rightWidth}px`
+  const maxLeftFor = (w: number): number => Math.max(MIN_SIDEBAR_PX, Math.round(w * 0.4))
+  const effectiveLeft = leftCollapsed ? 0 : Math.min(leftWidth, maxLeftFor(windowWidth))
+  const leftColW = leftCollapsed ? RIGHT_COLLAPSED_RAIL_PX : effectiveLeft
+  const maxRight = Math.max(MIN_RIGHT_PANEL_PX, windowWidth - leftColW - MIN_CENTER_GAP)
+  const effectiveRight = rightCollapsed ? RIGHT_COLLAPSED_RAIL_PX : Math.min(rightWidth, maxRight)
+
+  const leftCol = leftCollapsed ? '0px' : `${effectiveLeft}px`
+  const rightCol = rightCollapsed ? `${RIGHT_COLLAPSED_RAIL_PX}px` : `${effectiveRight}px`
   const gridCols = filesChatPreview
     ? `${leftCol} 0px minmax(0, 1fr)`
     : `${leftCol} minmax(0, 1fr) ${rightCol}`

--- a/src/renderer/src/features/workspace-files/workspace-files-panel.tsx
+++ b/src/renderer/src/features/workspace-files/workspace-files-panel.tsx
@@ -203,7 +203,11 @@ export function WorkspaceFilesPanel() {
       <div
         className={cn('files-split-grid min-h-0 flex-1', explorerCollapsed && 'files-split-grid--collapsed')}
         style={{
-          gridTemplateColumns: explorerCollapsed ? 'minmax(0, 1fr) 0px' : 'minmax(0, 1fr) 220px',
+          // Tree rail adapts to the panel width instead of a fixed 220px: it grows with wider
+          // panels (up to 240px) and yields space to the preview on narrow ones (min 150px).
+          gridTemplateColumns: explorerCollapsed
+            ? 'minmax(0, 1fr) 0px'
+            : 'minmax(0, 1fr) minmax(150px, min(240px, 38%))',
         }}
       >
         <div className="files-preview-scroll flex min-h-0 min-w-0 flex-col overflow-hidden bg-[var(--bg-base)]">


### PR DESCRIPTION
## 用户场景 / 问题
把窗口从大屏拖到小屏（或手动缩小窗口）后，左右面板保持旧的像素宽度，中间聊天区被挤压甚至溢出，需要手动重新拖动分隔条才能恢复。

## 代码问题
面板宽度是拖动时记录的固定像素值，窗口 resize 时没有按新窗口宽度做约束/收缩。

## 修复方案
监听窗口 resize，对面板宽度按可用空间做 clamp（保持用户比例意图，超限时收缩），恢复放大时不丢用户设置。