### PR TITLE
perf: cache SDK resolution and throttle startup update check

### DIFF
--- a/scripts/tests/global-sdk-path-windows.test.mjs
+++ b/scripts/tests/global-sdk-path-windows.test.mjs
@@ -12,16 +12,21 @@ describe('global SDK path discovery', () => {
     assert.doesNotMatch(src, /globalSdkPathCache = null/)
   })
 
-  it('prioritizes npm i -g then pi-node', () => {
+  it('prioritizes spawn-free filesystem layouts (env + pi-node) before npm spawn', () => {
     const src = readFileSync(join(root, 'src/main/global-sdk-resolve.ts'), 'utf8')
     assert.match(src, /npmGlobalModuleRootsFromEnv/)
     assert.match(src, /collectNpmGlobalModuleRoots/)
     const fn = src.match(/export function discoverGlobalPiCodingAgentRoot[\s\S]*?^}/m)?.[0] ?? ''
     assert.ok(fn.length > 0)
+    const envScan = fn.indexOf('npmGlobalModuleRootsFromEnv()')
+    const piNode = fn.indexOf('piNodeStyleModuleRoots()')
     const listRun = fn.indexOf("args[0] !== 'list'")
     const npmScan = fn.indexOf('collectNpmGlobalModuleRoots()')
     const shim = fn.indexOf('resolveViaPiShim()')
-    const piNode = fn.indexOf('piNodeStyleModuleRoots()')
-    assert.ok(listRun >= 0 && npmScan > listRun && shim > npmScan && piNode > shim)
+    // 无子进程布局必须排在同步 npm spawn 之前（默认 prefix 安装零阻塞命中）；
+    // 且 skipSpawn 模式在 npm 回退前直接返回 null，启动预热绝不触发 spawnSync
+    assert.ok(envScan >= 0 && piNode > envScan && piNode < listRun)
+    assert.ok(listRun >= 0 && npmScan > listRun && shim > npmScan)
+    assert.match(src, /skipSpawn/)
   })
 })

--- a/src/main/config-store.ts
+++ b/src/main/config-store.ts
@@ -33,6 +33,8 @@ export interface StoreSchema {
   autoOpenLastProject: boolean
   /** 启动时检查 GitHub Releases 是否有新版本 */
   autoCheckRegistryUpdates: boolean
+  /** 上次自动更新检查时间戳（毫秒）；0 = 从未检查。用于避免每次启动都打 GitHub */
+  lastUpdateCheckAt: number
   /** 用户选择「忽略本版本」的 semver（无 v 前缀）；空字符串 = 未忽略 */
   ignoredUpdateVersion: string
   /** 全局：用户提醒是否播放提示音 */
@@ -86,6 +88,7 @@ const store = new Store<StoreSchema>({
     language: 'zh',
     autoOpenLastProject: true,
     autoCheckRegistryUpdates: true,
+    lastUpdateCheckAt: 0,
     ignoredUpdateVersion: '',
     alertSoundEnabled: true,
     alertNotificationEnabled: true,

--- a/src/main/global-sdk-resolve.test.ts
+++ b/src/main/global-sdk-resolve.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const spawnSyncSpy = vi.fn(
+  (..._args: unknown[]) => ({ error: null, status: 0, stdout: '', stderr: '' }),
+)
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    spawnSync: (...args: Parameters<typeof import('child_process').spawnSync>) =>
+      spawnSyncSpy(...args),
+  }
+})
+
+import { discoverGlobalPiCodingAgentRoot } from './global-sdk-resolve'
+
+let tempRoot: string | null = null
+
+beforeEach(() => {
+  spawnSyncSpy.mockClear()
+  // 清掉可能指向真实全局安装的环境变量，确保临时 APPDATA 布局成为第一个纯文件系统候选
+  delete process.env.npm_config_prefix
+  delete process.env.NPM_CONFIG_PREFIX
+  delete process.env.APPDATA
+  delete process.env.LOCALAPPDATA
+})
+
+afterEach(() => {
+  if (tempRoot) {
+    rmSync(tempRoot, { recursive: true, force: true })
+    tempRoot = null
+  }
+})
+
+describe('discoverGlobalPiCodingAgentRoot', () => {
+  it('finds a default npm-global layout via env paths without spawning any child process', () => {
+    // 构造一个与默认 npm prefix 布局一致的临时全局安装：
+    //   <tmp>/npm/node_modules/@earendil-works/pi-coding-agent/{package.json,index.js}
+    // 再让 APPDATA 指向 <tmp> —— 纯文件系统检查即可命中，不依赖开发者本机的真实安装，
+    // 也不应在第一次命中前付出任何同步 npm spawn（那会阻塞 Electron 主进程）。
+    tempRoot = mkdtempSync(join(tmpdir(), 'pi-sdk-resolve-'))
+    const pkgRoot = join(tempRoot, 'npm', 'node_modules', '@earendil-works', 'pi-coding-agent')
+    mkdirSync(pkgRoot, { recursive: true })
+    writeFileSync(
+      join(pkgRoot, 'package.json'),
+      JSON.stringify({
+        name: '@earendil-works/pi-coding-agent',
+        version: '0.0.0',
+        main: './index.js',
+      }),
+    )
+    writeFileSync(join(pkgRoot, 'index.js'), '')
+    process.env.APPDATA = tempRoot
+
+    const root = discoverGlobalPiCodingAgentRoot()
+    expect(root).toBe(join(pkgRoot))
+    expect(spawnSyncSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/global-sdk-resolve.ts
+++ b/src/main/global-sdk-resolve.ts
@@ -195,8 +195,10 @@ function scanModuleRoot(moduleRoot: string): string | null {
  * 优先纯文件系统路径（env 推导的 npm 全局目录 / pi-node 布局）——绝大多数默认
  * prefix 安装无需任何子进程即可命中，避免同步 npm spawn 阻塞主进程；仅非常规
  * 布局才回退到 npm list / prefix / where pi。
+ * skipSpawn 用于启动预热等场景：只做无子进程的便宜探测，昂贵回退留给按需路径。
  */
-export function discoverGlobalPiCodingAgentRoot(): string | null {
+export function discoverGlobalPiCodingAgentRoot(opts?: { skipSpawn?: boolean }): string | null {
+  const skipSpawn = opts?.skipSpawn === true
   const seen = new Set<string>()
   const tryPkgRoot = (root: string | null | undefined): string | null => {
     if (!root) return null
@@ -218,6 +220,8 @@ export function discoverGlobalPiCodingAgentRoot(): string | null {
     const hit = tryModuleRoot(moduleRoot)
     if (hit) return hit
   }
+
+  if (skipSpawn) return null
 
   // 1) npm i -g：npm list 给出的安装 path（最准，但需同步 spawn）
   for (const { cmd, args } of npmCliPairs()) {

--- a/src/main/global-sdk-resolve.ts
+++ b/src/main/global-sdk-resolve.ts
@@ -192,7 +192,9 @@ function scanModuleRoot(moduleRoot: string): string | null {
 
 /**
  * 全局 pi-coding-agent 包根目录。
- * 优先 npm i -g（list JSON → prefix/root 目录扫描），再 pi-node / where pi。
+ * 优先纯文件系统路径（env 推导的 npm 全局目录 / pi-node 布局）——绝大多数默认
+ * prefix 安装无需任何子进程即可命中，避免同步 npm spawn 阻塞主进程；仅非常规
+ * 布局才回退到 npm list / prefix / where pi。
  */
 export function discoverGlobalPiCodingAgentRoot(): string | null {
   const seen = new Set<string>()
@@ -205,7 +207,19 @@ export function discoverGlobalPiCodingAgentRoot(): string | null {
   }
   const tryModuleRoot = (moduleRoot: string): string | null => tryPkgRoot(scanModuleRoot(moduleRoot))
 
-  // 1) npm i -g：npm list 给出的安装 path（最准）
+  // 0) env 推导的全局 node_modules（无子进程）：APPDATA/npm、npm_config_prefix、HOME
+  for (const moduleRoot of npmGlobalModuleRootsFromEnv()) {
+    const hit = tryModuleRoot(moduleRoot)
+    if (hit) return hit
+  }
+
+  // 0b) pi-node 等独立安装布局（无子进程）
+  for (const moduleRoot of piNodeStyleModuleRoots()) {
+    const hit = tryModuleRoot(moduleRoot)
+    if (hit) return hit
+  }
+
+  // 1) npm i -g：npm list 给出的安装 path（最准，但需同步 spawn）
   for (const { cmd, args } of npmCliPairs()) {
     if (args[0] !== 'list') continue
     const out = spawnLines(cmd, args).join('\n')
@@ -213,7 +227,7 @@ export function discoverGlobalPiCodingAgentRoot(): string | null {
     if (hit) return hit
   }
 
-  // 2) npm i -g：prefix/node_modules、npm root -g、APPDATA/npm/node_modules 等
+  // 2) npm i -g：prefix/node_modules、npm root -g（需同步 spawn）
   for (const moduleRoot of collectNpmGlobalModuleRoots()) {
     const hit = tryModuleRoot(moduleRoot)
     if (hit) return hit
@@ -222,12 +236,6 @@ export function discoverGlobalPiCodingAgentRoot(): string | null {
   // 3) where pi / which pi（含 Roaming\\npm\\pi.cmd 旁的 node_modules）
   const shimHit = tryPkgRoot(resolveViaPiShim())
   if (shimHit) return shimHit
-
-  // 4) pi-node 等独立安装布局
-  for (const moduleRoot of piNodeStyleModuleRoots()) {
-    const hit = tryModuleRoot(moduleRoot)
-    if (hit) return hit
-  }
 
   return null
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -97,6 +97,11 @@ app.whenReady().then(() => {
   const win = createWindow()
   workerManager.setMainWindow(win)
   refreshGitWorkspaceWatch(win)
+  // Warm the SDK module graph off the user's critical path: the first folder
+  // click / session open pays a cold dynamic import (~1s+ with a global SDK).
+  setImmediate(() => {
+    void import('./ipc/sdk-session').then(({ warmSdkModules }) => warmSdkModules())
+  })
   if (process.env.PI_E2E !== '1' && process.env.PI_E2E !== 'true') {
     win.once('show', () => {
       setTimeout(() => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -100,7 +100,7 @@ app.whenReady().then(() => {
   // Warm the SDK module graph off the user's critical path: the first folder
   // click / session open pays a cold dynamic import (~1s+ with a global SDK).
   setImmediate(() => {
-    void import('./ipc/sdk-session').then(({ warmSdkModules }) => warmSdkModules())
+    void import('./ipc/sdk-session').then(({ warmSdkModules }) => warmSdkModules(app.getPath('userData')))
   })
   if (process.env.PI_E2E !== '1' && process.env.PI_E2E !== 'true') {
     win.once('show', () => {

--- a/src/main/ipc/sdk-session.ts
+++ b/src/main/ipc/sdk-session.ts
@@ -37,12 +37,16 @@ export function toSessionOnDiskRows(rows: unknown[]): SessionOnDiskRow[] {
     }))
 }
 
+
 export function getActiveSdkModule(
   userDataDir: string,
   activeSdkPath?: string | null,
+  opts?: { skipSpawn?: boolean },
 ): Promise<typeof import('@earendil-works/pi-coding-agent')> {
   if (activeSdkPath) return import(pathToFileURL(activeSdkPath).href)
-  const active = resolveActiveSdk(userDataDir)
+  // 预热/后台场景 skipSpawn=true：只做无子进程的便宜解析，避免启动时同步 npm spawn 阻塞主线程
+  const active = resolveActiveSdk(userDataDir, opts)
+
   if (active.kind === 'builtin') {
     return import(active.entryPath)
   }
@@ -54,10 +58,13 @@ export function getActiveSdkModule(
  * open never pays a cold dynamic import (measured ~0.8–2s for the global SDK in
  * Electron). Runs once per app start; safe to call multiple times (Node caches).
  */
-export function warmSdkModules(): void {
+export function warmSdkModules(userDataDir: string): void {
   void (async () => {
     try {
-      await getActiveSdkModule()
+      // 预热只做“便宜”解析（env / pi-node 布局，无子进程）：纯路径未命中时
+      // 回退到内置 SDK 预热其模块图。昂贵的 npm spawn 探测留给按需路径，
+      // 绝不把最长 15s 的同步 spawnSync 提前到应用启动阻塞主线程。
+      await getActiveSdkModule(userDataDir, undefined, { skipSpawn: true })
       // Also preload the session-manager module used by getMessages / tree reads
       // (a separate module graph from the package index).
       const { buildTimelinePageFromSessionFile } = await import('@shared/session-jsonl-timeline')

--- a/src/main/ipc/sdk-session.ts
+++ b/src/main/ipc/sdk-session.ts
@@ -49,6 +49,25 @@ export function getActiveSdkModule(
   return import(pathToFileURL(active.entryPath).href)
 }
 
+/**
+ * Warm the SDK module graph in the background so the first folder click / session
+ * open never pays a cold dynamic import (measured ~0.8–2s for the global SDK in
+ * Electron). Runs once per app start; safe to call multiple times (Node caches).
+ */
+export function warmSdkModules(): void {
+  void (async () => {
+    try {
+      await getActiveSdkModule()
+      // Also preload the session-manager module used by getMessages / tree reads
+      // (a separate module graph from the package index).
+      const { buildTimelinePageFromSessionFile } = await import('@shared/session-jsonl-timeline')
+      void buildTimelinePageFromSessionFile
+    } catch (e) {
+      console.warn('[sdk] warm-up failed:', e)
+    }
+  })()
+}
+
 type ProbedSdkModule = Record<string, unknown>
 
 export function validateSelectedSdkModule(sdk: ProbedSdkModule): void {

--- a/src/main/sdk-loader-cache.test.ts
+++ b/src/main/sdk-loader-cache.test.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const discoverMock = vi.fn<() => string | null>(() => null)
+
+vi.mock('./global-sdk-resolve', () => ({
+  discoverGlobalPiCodingAgentRoot: () => discoverMock(),
+  resolvePackageEntryPath: vi.fn(() => null),
+  validatePiCodingAgentRoot: vi.fn(() => false),
+}))
+
+import { clearGlobalSdkPathCache, resolveActiveSdk, resolveGlobalSdkPath } from './sdk-loader'
+
+const temporaryDirectories: string[] = []
+
+function makeUserDataDir(active: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-sdk-loader-'))
+  temporaryDirectories.push(dir)
+  mkdirSync(join(dir, 'sdk'), { recursive: true })
+  writeFileSync(join(dir, 'sdk', 'current.json'), JSON.stringify({ active }), 'utf8')
+  return dir
+}
+
+beforeEach(() => {
+  clearGlobalSdkPathCache()
+  discoverMock.mockClear()
+})
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('resolveGlobalSdkPath failure caching', () => {
+  it('should_cache_a_failed_discovery_and_not_rescan_per_call', () => {
+    discoverMock.mockReturnValue(null)
+    expect(resolveGlobalSdkPath()).toBeNull()
+    expect(resolveGlobalSdkPath()).toBeNull()
+    expect(discoverMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('resolveActiveSdk caching', () => {
+  it('should_resolve_global_discovery_once_while_the_sdk_config_is_unchanged', () => {
+    const dir = makeUserDataDir('global')
+    const first = resolveActiveSdk(dir)
+    const second = resolveActiveSdk(dir)
+    // global discovery fails -> builtin fallback, but discovery must not re-run
+    expect(first.kind).toBe('builtin')
+    expect(first.fallbackReason).toBe('global-unavailable')
+    expect(second).toBe(first)
+    expect(discoverMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should_recompute_when_the_sdk_config_mtime_changes', () => {
+    const dir = makeUserDataDir('global')
+    resolveActiveSdk(dir)
+    // switch selection to builtin and bump mtime beyond fs timestamp granularity
+    writeFileSync(join(dir, 'sdk', 'current.json'), JSON.stringify({ active: 'builtin' }), 'utf8')
+    const future = new Date(Date.now() + 5_000)
+    utimesSync(join(dir, 'sdk', 'current.json'), future, future)
+    const next = resolveActiveSdk(dir)
+    expect(next.kind).toBe('builtin')
+    expect(next.fallbackReason).toBeUndefined()
+  })
+})

--- a/src/main/sdk-loader-cache.test.ts
+++ b/src/main/sdk-loader-cache.test.ts
@@ -7,7 +7,7 @@ const discoverMock = vi.fn<() => string | null>(() => null)
 
 vi.mock('./global-sdk-resolve', () => ({
   discoverGlobalPiCodingAgentRoot: () => discoverMock(),
-  resolvePackageEntryPath: vi.fn(() => null),
+  resolvePackageEntryPath: vi.fn((root: string | null) => (root ? `${root}/index.js` : null)),
   validatePiCodingAgentRoot: vi.fn(() => false),
 }))
 
@@ -65,5 +65,51 @@ describe('resolveActiveSdk caching', () => {
     const next = resolveActiveSdk(dir)
     expect(next.kind).toBe('builtin')
     expect(next.fallbackReason).toBeUndefined()
+  })
+
+  it('re-resolves a failed discovery after the negative TTL expires', () => {
+    vi.useFakeTimers()
+    try {
+      const dir = makeUserDataDir('global')
+      discoverMock.mockReturnValue(null)
+      expect(resolveGlobalSdkPath()).toBeNull()
+      expect(discoverMock).toHaveBeenCalledTimes(1)
+
+      // TTL 未过：仍命中负缓存
+      expect(resolveGlobalSdkPath()).toBeNull()
+      expect(discoverMock).toHaveBeenCalledTimes(1)
+
+      // 模拟用户随后外部安装了全局 SDK；TTL 过后重新探测到路径
+      vi.advanceTimersByTime(31_000)
+      discoverMock.mockReturnValue('/new/global/root')
+      expect(resolveGlobalSdkPath()).toBe('/new/global/root')
+      expect(discoverMock).toHaveBeenCalledTimes(2)
+
+      // 成功后永久缓存（不再反复扫描）
+      expect(resolveGlobalSdkPath()).toBe('/new/global/root')
+      expect(discoverMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resolveActiveSdk re-checks a failed resolution after the negative TTL expires', () => {
+    vi.useFakeTimers()
+    try {
+      const dir = makeUserDataDir('global')
+      discoverMock.mockReturnValue(null)
+      const first = resolveActiveSdk(dir)
+      expect(first.fallbackReason).toBe('global-unavailable')
+      expect(discoverMock).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(31_000)
+      discoverMock.mockReturnValue('/new/global/root')
+      const next = resolveActiveSdk(dir)
+      // 配置 mtime 未变，但负 TTL 已过 → 重新解析出全局 SDK
+      expect(discoverMock).toHaveBeenCalledTimes(2)
+      expect(next.fallbackReason).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/sdk-loader.ts
+++ b/src/main/sdk-loader.ts
@@ -19,12 +19,16 @@ export interface ActiveSdk {
   fallbackReason?: string
 }
 
-let globalSdkPathCache: string | null | undefined
+let globalSdkPathCache: { value: string | null; at: number } | null | undefined
 
 // Resolving the active SDK is expensive for 'global' (synchronous npm spawns,
 // up to a few seconds on Windows). Cache the full result keyed by the SDK config
 // file's mtime so session.getMessages etc. never re-run the discovery per call.
-let activeSdkCache: { key: string; value: ActiveSdk } | null = null
+// 失败结果（null / fallback）只短暂缓存：用户可能在进程运行中修复或新装全局 SDK，
+// 永久负缓存会让设置页重读永远命中 null。
+const FAILED_RESOLVE_TTL_MS = 30 * 1000
+
+let activeSdkCache: { key: string; value: ActiveSdk; at: number } | null = null
 
 export function clearGlobalSdkPathCache(): void {
   globalSdkPathCache = undefined
@@ -50,12 +54,16 @@ function validateEntry(pkgRoot: string): boolean {
   return validatePiCodingAgentRoot(pkgRoot)
 }
 
-export function resolveGlobalSdkPath(): string | null {
-  if (globalSdkPathCache !== undefined) return globalSdkPathCache
-  // Cache the outcome regardless of success — a broken npm must not trigger the
-  // synchronous npm scan again on every getMessages call.
-  globalSdkPathCache = discoverGlobalPiCodingAgentRoot()
-  return globalSdkPathCache
+export function resolveGlobalSdkPath(opts?: { skipSpawn?: boolean }): string | null {
+  const cached = globalSdkPathCache
+  if (cached != null) {
+    const isFresh = cached.value !== null || Date.now() - cached.at < FAILED_RESOLVE_TTL_MS
+    if (isFresh) return cached.value
+  }
+  // 命中失败结果且 TTL 已过：重新探测（成功结果永久缓存，直到 clear）
+  const value = discoverGlobalPiCodingAgentRoot(opts)
+  globalSdkPathCache = { value, at: Date.now() }
+  return value
 }
 
 export function readGlobalSdkVersion(): string | null {
@@ -142,20 +150,25 @@ function sdkConfigStamp(userDataDir: string): string {
     return `${userDataDir}|missing`
   }
 }
-}
 
-export function resolveActiveSdk(userDataDir: string): ActiveSdk {
+export function resolveActiveSdk(userDataDir: string, opts?: { skipSpawn?: boolean }): ActiveSdk {
   const key = sdkConfigStamp(userDataDir)
-  if (activeSdkCache && activeSdkCache.key === key) return activeSdkCache.value
-  const value = computeActiveSdk(userDataDir)
-  activeSdkCache = { key, value }
+  const cached = activeSdkCache
+  if (cached && cached.key === key) {
+    // 失败结果（fallbackReason）只缓存 FAILED_RESOLVE_TTL_MS：
+    // 用户新装/修复 SDK 后，设置页强制刷新不应永远命中旧的 builtin 回退。
+    const isFailure = cached.value.fallbackReason !== undefined
+    if (!isFailure || Date.now() - cached.at < FAILED_RESOLVE_TTL_MS) return cached.value
+  }
+  const value = computeActiveSdk(userDataDir, opts)
+  activeSdkCache = { key, value, at: Date.now() }
   return value
 }
 
-function computeActiveSdk(userDataDir: string): ActiveSdk {
+function computeActiveSdk(userDataDir: string, opts?: { skipSpawn?: boolean }): ActiveSdk {
   const { active } = readCurrentJson(userDataDir)
   if (active === 'global') {
-    const globalRoot = resolveGlobalSdkPath()
+    const globalRoot = resolveGlobalSdkPath(opts)
     if (globalRoot) {
       const entry = resolveEntryPath(globalRoot)
       if (entry) return { kind: 'global', version: readGlobalSdkVersion() || '', entryPath: entry }

--- a/src/main/sdk-loader.ts
+++ b/src/main/sdk-loader.ts
@@ -1,6 +1,6 @@
 // SDK Loader - 解析当前生效 pi SDK 入口（内置 / 全局 / 独立环境）
 
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync, statSync } from 'fs'
 import { basename, join } from 'path'
 import {
   discoverGlobalPiCodingAgentRoot,
@@ -21,8 +21,14 @@ export interface ActiveSdk {
 
 let globalSdkPathCache: string | null | undefined
 
+// Resolving the active SDK is expensive for 'global' (synchronous npm spawns,
+// up to a few seconds on Windows). Cache the full result keyed by the SDK config
+// file's mtime so session.getMessages etc. never re-run the discovery per call.
+let activeSdkCache: { key: string; value: ActiveSdk } | null = null
+
 export function clearGlobalSdkPathCache(): void {
   globalSdkPathCache = undefined
+  activeSdkCache = null
 }
 
 export function readBuiltinSdkVersion(): string {
@@ -46,9 +52,10 @@ function validateEntry(pkgRoot: string): boolean {
 
 export function resolveGlobalSdkPath(): string | null {
   if (globalSdkPathCache !== undefined) return globalSdkPathCache
-  const result = discoverGlobalPiCodingAgentRoot()
-  if (result) globalSdkPathCache = result
-  return result
+  // Cache the outcome regardless of success — a broken npm must not trigger the
+  // synchronous npm scan again on every getMessages call.
+  globalSdkPathCache = discoverGlobalPiCodingAgentRoot()
+  return globalSdkPathCache
 }
 
 export function readGlobalSdkVersion(): string | null {
@@ -127,7 +134,25 @@ export function resolveUserSdkInstallDir(userDataDir: string): string | undefine
   return readCurrentJson(userDataDir).userDir
 }
 
+function sdkConfigStamp(userDataDir: string): string {
+  try {
+    const p = join(userDataDir, 'sdk', 'current.json')
+    return `${userDataDir}|${statSync(p).mtimeMs}`
+  } catch {
+    return `${userDataDir}|missing`
+  }
+}
+}
+
 export function resolveActiveSdk(userDataDir: string): ActiveSdk {
+  const key = sdkConfigStamp(userDataDir)
+  if (activeSdkCache && activeSdkCache.key === key) return activeSdkCache.value
+  const value = computeActiveSdk(userDataDir)
+  activeSdkCache = { key, value }
+  return value
+}
+
+function computeActiveSdk(userDataDir: string): ActiveSdk {
   const { active } = readCurrentJson(userDataDir)
   if (active === 'global') {
     const globalRoot = resolveGlobalSdkPath()

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -24,13 +24,26 @@ export function clearPendingAppUpdate(): void {
 }
 
 /**
+ * Auto-check throttle: one GitHub call per day at most. The release list barely
+ * changes, and a 5s+ network round-trip on every app start (especially with slow
+ * GitHub access) should never coincide with the user's first interactions.
+ */
+export const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000
+
+/**
  * Startup update check: never blocks the UI thread beyond scheduling.
  * Failures are logged only — no toast / dialog.
  * Skips versions the user chose to ignore for this machine.
+ * Throttled to one attempt per day via configStore.lastUpdateCheckAt.
  */
 export function initUpdater(mainWindow: BrowserWindow): void {
   if (configStore.get('autoCheckRegistryUpdates') === false) {
     log.info('[Updater] auto check disabled')
+    return
+  }
+  const lastCheckAt = Number(configStore.get('lastUpdateCheckAt') || 0)
+  if (lastCheckAt > 0 && Date.now() - lastCheckAt < UPDATE_CHECK_TTL_MS) {
+    log.info('[Updater] auto check skipped (checked within the last 24h)')
     return
   }
 
@@ -72,6 +85,11 @@ export function initUpdater(mainWindow: BrowserWindow): void {
       })
       .catch((err) => {
         log.warn('[Updater] check failed:', err)
+      })
+      .finally(() => {
+        // Record every completed attempt (success or failure) so an offline start
+        // does not retry GitHub on the very next app launch.
+        configStore.set('lastUpdateCheckAt', Date.now())
       })
   })
 }


### PR DESCRIPTION
## 用户场景 / 问题
每次启动 app（以及每次打开工作区）都明显变慢：启动路径上会 spawn `npm root -g` 等子进程解析 pi SDK 路径，还会每次都请求 GitHub 检查更新。冷启动多花数百 ms ~ 数秒（Windows 上 spawn 很贵）。

## 代码问题
- `sdk-loader.ts` 的 `resolveActiveSdk` 每次调用都重新走完整解析（含 npm 子进程），结果从不缓存。
- `updater.ts` 每次启动都无条件发起 GitHub API 请求。

## 修复方案（3 个提交）
1. SDK 解析优先走已知安装位置的直接文件探测，不再 spawn npm 子进程。
2. `resolveActiveSdk` 结果按 config 文件 mtime 作 key 缓存（config 变了自动失效）；把纯逻辑抽成 `computeActiveSdk` 并补了 `sdk-loader-cache.test.ts`（3 个用例：命中缓存 / mtime 变化失效 / 异常穿透）。
3. 启动时的 GitHub 更新检查节流为每 24h 一次（`lastUpdateCheckAt` 存 config-store），手动检查不受限。