### PR TITLE
feat(sidebar): optional fixed project order + fix order flicker on switch

### DIFF
--- a/doc/CONTEXT.md
+++ b/doc/CONTEXT.md
@@ -4,6 +4,8 @@
 
 侧栏项目列表默认按最近使用（MRU）排序：打开项目时 `configStore.addRecentProject` 把项目移到最前，且当前工作区始终置顶（`project-sidebar.tsx` 的 `diskPaths`）。新增配置项 `recentProjectsFixedOrder`（默认 `false`，保持 MRU 行为）：开启后 `nextRecentProjects` 不再移动已有项目（新项目追加到末尾），侧栏按存储顺序展示且当前项目不置顶（仅高亮）。纯函数：`src/main/recent-projects.ts`、`src/renderer/src/features/workspace/project-folder-order.ts`。设置页「最近项目」区开关直接写配置并派发 `pi-desktop:settings-changed` 事件通知侧栏即时重排。
 
+**闪烁根因（勿回退）**：`ui-store.setWorkspace` 曾把当前工作区 unshift 到 `recentProjects` 最前——固定模式下侧栏先跳顶，随后 `reloadSidebarSettings` 从主进程拉回真实顺序——先跳再弹回 = 每次切换可见闪烁。修复：`setWorkspace` 不再重排 `recentProjects`（侧栏顺序以主进程配置为唯一事实源；MRU 模式由 `projectFolderOrder` 的“当前置顶”规则兜底即时显示）。另：`reloadSidebarSettings` 在顺序无变化时保持数组引用稳定，避免固定模式下每次切换都触发整个侧栏重渲染。
+
 ## 进程边界
 
 | 进程 | 目录 | 职责 |

--- a/doc/CONTEXT.md
+++ b/doc/CONTEXT.md
@@ -1,5 +1,9 @@
 # pi-app 架构上下文（审计 / 重构用）
 
+### 决策记录：侧栏项目固定顺序（2026）
+
+侧栏项目列表默认按最近使用（MRU）排序：打开项目时 `configStore.addRecentProject` 把项目移到最前，且当前工作区始终置顶（`project-sidebar.tsx` 的 `diskPaths`）。新增配置项 `recentProjectsFixedOrder`（默认 `false`，保持 MRU 行为）：开启后 `nextRecentProjects` 不再移动已有项目（新项目追加到末尾），侧栏按存储顺序展示且当前项目不置顶（仅高亮）。纯函数：`src/main/recent-projects.ts`、`src/renderer/src/features/workspace/project-folder-order.ts`。设置页「最近项目」区开关直接写配置并派发 `pi-desktop:settings-changed` 事件通知侧栏即时重排。
+
 ## 进程边界
 
 | 进程 | 目录 | 职责 |

--- a/src/main/config-store.ts
+++ b/src/main/config-store.ts
@@ -4,9 +4,12 @@ import type { CustomCssOverride, CustomTheme } from '@shared/custom-theme'
 import { DEFAULT_ICON_THEME, type IconTheme } from '@shared/icon-theme'
 import { DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS } from '@shared/timeline-settings'
 import { bindSecretStoreBacking } from './secret-store'
+import { nextRecentProjects } from './recent-projects'
 
 export interface StoreSchema {
   recentProjects: string[]
+  /** 侧栏项目列表固定顺序（不随打开而置顶）；false = 最近使用排序（默认） */
+  recentProjectsFixedOrder: boolean
   currentProject: string | null
   windowBounds: { width: number; height: number; x?: number; y?: number } | null
   theme: 'light' | 'dark' | 'system'
@@ -60,6 +63,7 @@ const store = new Store<StoreSchema>({
   name: 'pi-desktop',
   defaults: {
     recentProjects: [],
+    recentProjectsFixedOrder: false,
     currentProject: null,
     windowBounds: null,
     theme: 'system',
@@ -125,9 +129,10 @@ export const configStore = {
   },
 
   addRecentProject(path: string): void {
-    const recent = store.get('recentProjects').filter((p: string) => p !== path)
-    recent.unshift(path)
-    store.set('recentProjects', recent.slice(0, 10))
+    store.set(
+      'recentProjects',
+      nextRecentProjects(store.get('recentProjects'), path, store.get('recentProjectsFixedOrder')),
+    )
   },
 
   removeRecentProject(path: string): void {

--- a/src/main/ipc/schemas.ts
+++ b/src/main/ipc/schemas.ts
@@ -152,6 +152,7 @@ const settingsValueSchemas: Record<string, z.ZodTypeAny> = {
   language: z.enum(['zh', 'en']),
   currentProject: z.string().nullable(),
   recentProjects: z.array(z.string()),
+  recentProjectsFixedOrder: z.boolean(),
   autoOpenLastProject: z.boolean(),
   autoCheckRegistryUpdates: z.boolean(),
   ignoredUpdateVersion: z.string(),

--- a/src/main/recent-projects.test.ts
+++ b/src/main/recent-projects.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { RECENT_PROJECTS_CAP, nextRecentProjects } from './recent-projects'
+
+describe('nextRecentProjects', () => {
+  describe('MRU mode (default, fixedOrder=false)', () => {
+    it('moves an existing project to the front', () => {
+      expect(nextRecentProjects(['a', 'b', 'c'], 'b', false)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('puts a new project at the front', () => {
+      expect(nextRecentProjects(['a', 'b'], 'c', false)).toEqual(['c', 'a', 'b'])
+    })
+
+    it('caps at the most recent 10', () => {
+      const full = Array.from({ length: RECENT_PROJECTS_CAP }, (_, i) => `p${i}`)
+      const next = nextRecentProjects(full, 'new', false)
+      expect(next).toHaveLength(RECENT_PROJECTS_CAP)
+      expect(next[0]).toBe('new')
+      expect(next).not.toContain('p9')
+    })
+  })
+
+  describe('fixed order (fixedOrder=true)', () => {
+    it('keeps existing projects in place', () => {
+      expect(nextRecentProjects(['a', 'b', 'c'], 'b', true)).toEqual(['a', 'b', 'c'])
+      expect(nextRecentProjects(['a', 'b', 'c'], 'c', true)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('appends a new project at the end', () => {
+      expect(nextRecentProjects(['a', 'b'], 'c', true)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('caps by dropping the oldest (first) entry', () => {
+      const full = Array.from({ length: RECENT_PROJECTS_CAP }, (_, i) => `p${i}`)
+      const next = nextRecentProjects(full, 'new', true)
+      expect(next).toHaveLength(RECENT_PROJECTS_CAP)
+      expect(next[next.length - 1]).toBe('new')
+      expect(next).not.toContain('p0')
+    })
+  })
+})

--- a/src/main/recent-projects.ts
+++ b/src/main/recent-projects.ts
@@ -1,0 +1,17 @@
+/** 项目 MRU 列表上限（与 config-store 历史行为一致）。 */
+export const RECENT_PROJECTS_CAP = 10
+
+/**
+ * 计算 addRecentProject 之后的新列表。
+ * fixedOrder=true：顺序固定，已有项目保持不变，新项目追加到末尾（超出上限时丢弃最旧的）；
+ * fixedOrder=false（默认）：最近使用优先，项目移到最前（超出上限时丢弃最旧的）。
+ */
+export function nextRecentProjects(recent: string[], path: string, fixedOrder: boolean): string[] {
+  if (fixedOrder) {
+    if (recent.includes(path)) return recent
+    return [...recent, path].slice(-RECENT_PROJECTS_CAP)
+  }
+  const next = recent.filter((p) => p !== path)
+  next.unshift(path)
+  return next.slice(0, RECENT_PROJECTS_CAP)
+}

--- a/src/renderer/src/features/settings/settings-general-appearance.tsx
+++ b/src/renderer/src/features/settings/settings-general-appearance.tsx
@@ -39,6 +39,7 @@ export function GeneralSettings() {
     setSessionWorkerIdleTimeoutMinutes,
   } = useSettingsDraft()
   const [recentProjects, setRecentProjects] = useState<string[]>([])
+  const [fixedOrder, setFixedOrder] = useState(false)
   const [updateCheck, setUpdateCheck] = useState<string | null>(null)
   const [checkingUpdate, setCheckingUpdate] = useState(false)
   const [advancedOpen, setAdvancedOpen] = useState(false)
@@ -55,7 +56,20 @@ export function GeneralSettings() {
     ipcClient.invoke('settings.get', { key: 'recentProjects' }).then((res) => {
       if (res?.settings?.recentProjects) setRecentProjects(res.settings.recentProjects)
     })
+    ipcClient.invoke('settings.get', { key: 'recentProjectsFixedOrder' }).then((res) => {
+      if (typeof res?.settings?.recentProjectsFixedOrder === 'boolean') {
+        setFixedOrder(res.settings.recentProjectsFixedOrder)
+      }
+    })
   }, [])
+
+  const toggleFixedOrder = (next: boolean) => {
+    setFixedOrder(next)
+    void ipcClient.invoke('settings.set', { key: 'recentProjectsFixedOrder', value: next }).then(() => {
+      // 通知侧栏立即按新顺序重排
+      window.dispatchEvent(new CustomEvent('pi-desktop:settings-changed', { detail: { key: 'recentProjectsFixedOrder' } }))
+    })
+  }
 
   const handleCheckUpdate = () => {
     setCheckingUpdate(true)
@@ -241,6 +255,9 @@ export function GeneralSettings() {
       <RuntimeSettingsPanel />
 
       <SettingsSection title={t('settings:general.recentProjects')}>
+        <SettingRow label={t('settings:general.fixedOrder')} description={t('settings:general.fixedOrderDesc')}>
+          <Switch checked={fixedOrder} onCheckedChange={toggleFixedOrder} />
+        </SettingRow>
         {recentProjects.length > 0 ? (
           <div className="space-y-1 py-3">
             {recentProjects.map((p, i) => (

--- a/src/renderer/src/features/workspace/project-folder-order.test.ts
+++ b/src/renderer/src/features/workspace/project-folder-order.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { projectFolderOrder } from './project-folder-order'
+
+describe('projectFolderOrder', () => {
+  it('MRU mode (default): pins the current workspace to the top, then stored order', () => {
+    expect(projectFolderOrder(['a', 'b', 'c'], 'b', false)).toEqual(['b', 'a', 'c'])
+    expect(projectFolderOrder(['a', 'c'], 'b', false)).toEqual(['b', 'a', 'c'])
+    expect(projectFolderOrder([], 'b', false)).toEqual(['b'])
+  })
+
+  it('fixed mode: keeps the stored order and never pins the current workspace', () => {
+    expect(projectFolderOrder(['a', 'b', 'c'], 'b', true)).toEqual(['a', 'b', 'c'])
+    // 当前项目不在列表时追加到末尾（仅保证存在，不置顶）
+    expect(projectFolderOrder(['a', 'c'], 'b', true)).toEqual(['a', 'c', 'b'])
+    expect(projectFolderOrder([], 'b', true)).toEqual(['b'])
+  })
+
+  it('dedupes and ignores falsy entries', () => {
+    expect(projectFolderOrder(['a', 'a', 'b'], 'a', false)).toEqual(['a', 'b'])
+    expect(projectFolderOrder(['a', 'b'], null, false)).toEqual(['a', 'b'])
+    expect(projectFolderOrder(['', 'a'], null, true)).toEqual(['a'])
+  })
+})

--- a/src/renderer/src/features/workspace/project-folder-order.ts
+++ b/src/renderer/src/features/workspace/project-folder-order.ts
@@ -1,0 +1,21 @@
+/** 侧栏项目文件夹的显示顺序。 */
+export function projectFolderOrder(
+  recentProjects: string[],
+  currentWorkspace: string | null | undefined,
+  fixedOrder: boolean,
+): string[] {
+  const out: string[] = []
+  const add = (p: string) => {
+    if (p && !out.includes(p)) out.push(p)
+  }
+  if (fixedOrder) {
+    // 固定顺序：完全按存储顺序展示，当前项目不置顶，仅保证在列表中
+    for (const p of recentProjects) add(p)
+    if (currentWorkspace) add(currentWorkspace)
+  } else {
+    // 最近使用（默认）：当前项目置顶，其余按 MRU
+    if (currentWorkspace) add(currentWorkspace)
+    for (const p of recentProjects) add(p)
+  }
+  return out
+}

--- a/src/renderer/src/features/workspace/project-sidebar-flicker.test.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar-flicker.test.tsx
@@ -167,4 +167,41 @@ describe('ProjectSidebar folder list stability', () => {
     expect(after.join('')).not.toContain('加载中')
     expect(after.join('')).toContain('B的会话')
   })
+
+  it('prefers the live session list over a stale cache so a new session is not hidden', async () => {
+    const { container } = render(<ProjectSidebar onOpenProject={() => {}} openProjectLabel="打开" />)
+    await act(async () => {
+      resolveRecentProjects?.({ settings: { recentProjects: ['/proj/A', '/proj/B'] } })
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    // B 已有旧缓存（来自之前的访问）
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('pi-desktop:workspace-sessions', {
+          detail: { workspaceId: '/proj/B', sessions: [{ sessionId: 'b1', title: 'B的旧会话', updatedAt: 2, modelId: 'm' }] },
+        }),
+      )
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    // 切换到 B（setWorkspace 清空 store.sessions → 瞬态期显示缓存）
+    await act(async () => {
+      useUIStore.getState().setWorkspace('/proj/B')
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
+
+    // 新建会话只更新 store.sessions、不发布 workspace-sessions 事件：
+    // 实时列表必须优先于旧缓存，否则新会话被旧缓存遮蔽
+    await act(async () => {
+      useUIStore.getState().setSessions([
+        { sessionId: 'b1', title: 'B的旧会话', updatedAt: 2, modelId: 'm' },
+        { sessionId: 'b2', title: '新会话', updatedAt: 3, modelId: 'm' },
+      ])
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    const treeText = [...container.querySelectorAll('.sidebar-session-tree')].map((t) => t.textContent)
+    expect(treeText.join('')).toContain('新会话')
+  })
 })

--- a/src/renderer/src/features/workspace/project-sidebar-flicker.test.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar-flicker.test.tsx
@@ -1,0 +1,170 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProjectSidebar } from './project-sidebar'
+import { useUIStore } from '@renderer/stores/ui-store'
+
+/** settings.get(recentProjects) 的响应延迟可控制，用来暴露 setWorkspace 到 reload 之间的瞬态帧 */
+let resolveRecentProjects: ((v: unknown) => void) | null = null
+let deferNextRecentProjects = false
+/** session.list 延迟可控制，用来暴露切换后会话列表重新加载期间的帧 */
+let resolveNextSessionList: ((v: unknown) => void) | null = null
+let deferNextSessionList = false
+
+const invokeMock = vi.fn(async (method: string, req?: { key?: string; workspaceId?: string }) => {
+  if (method === 'session.list') {
+    if (deferNextSessionList) {
+      return new Promise((res) => {
+        resolveNextSessionList = res
+      })
+    }
+    return { sessions: [{ sessionId: 's1', title: '会话1', updatedAt: 1, modelId: 'm' }] }
+  }
+  if (method === 'settings.get' && req?.key === 'recentProjects') {
+    if (deferNextRecentProjects) {
+      return new Promise((res) => {
+        resolveRecentProjects = res
+      })
+    }
+    return { settings: { recentProjects: ['/proj/A', '/proj/B', '/proj/C'] } }
+  }
+  if (method === 'settings.get' && req?.key === 'recentProjectsFixedOrder') {
+    return { settings: { recentProjectsFixedOrder: true } }
+  }
+  if (method === 'session.list') return { sessions: [{ sessionId: 's1', title: '会话1', updatedAt: 1, modelId: 'm' }] }
+  if (method === 'workspace.sandbox.list') return { sandboxes: [] }
+  if (method === 'workspace.open' || method === 'settings.set') return { ok: true }
+  return {}
+})
+
+vi.mock('@renderer/lib/ipc-client', () => ({ ipcClient: { invoke: (method: string, req?: { key?: string }) => invokeMock(method, req) } }))
+vi.mock('@renderer/lib/refresh-workspace-session-lists', () => ({
+  refreshWorkspaceSessionLists: vi.fn(async () => {}),
+}))
+vi.mock('@renderer/lib/activate-workspace', () => ({
+  activateWorkspace: vi.fn(async () => {}),
+  switchSessionInPlace: vi.fn(async () => {}),
+  previewSessionInPlace: vi.fn(async () => {}),
+}))
+vi.mock('@renderer/features/timeline/tool-card-registry', () => ({
+  useToolCardCatalogReady: () => true,
+}))
+
+const ROWS_ABC = [expect.stringContaining('A'), expect.stringContaining('B'), expect.stringContaining('C')]
+
+describe('ProjectSidebar folder list stability', () => {
+  beforeEach(() => {
+    resolveRecentProjects = null
+    deferNextRecentProjects = false
+    resolveNextSessionList = null
+    deferNextSessionList = false
+    invokeMock.mockClear()
+    useUIStore.setState({
+      currentWorkspace: '/proj/A',
+      recentProjects: [],
+      sessions: [],
+      currentSessionId: null,
+      historySessionFile: null,
+      timelineItems: [],
+      subagentSessionGroup: null,
+      sessionRuntimeRunning: {},
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps the folder order stable on every frame of a workspace switch (fixed order)', async () => {
+    const { container } = render(
+      <ProjectSidebar onOpenProject={() => {}} openProjectLabel="打开" />,
+    )
+
+    // 首次加载：放行 recentProjects，让列表就位 [A,B,C]
+    await act(async () => {
+      resolveRecentProjects?.({ settings: { recentProjects: ['/proj/A', '/proj/B', '/proj/C'] } })
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    const rows = () => [...container.querySelectorAll('.sidebar-project-row')]
+    expect(rows().length).toBeGreaterThanOrEqual(3)
+    expect(rows().map((r) => r.textContent)).toEqual(ROWS_ABC)
+
+    // 切换工作区：本次 recentProjects 响应挂起（模拟真实 IPC 延迟）
+    deferNextRecentProjects = true
+    await act(async () => {
+      useUIStore.getState().setWorkspace('/proj/B')
+    })
+    // setWorkspace 之后的这一帧：固定顺序下列表不允许跳顶（否则就是闪烁）
+    expect(rows().map((r) => r.textContent)).toEqual(ROWS_ABC)
+    const frameNodes = rows()
+    for (const node of frameNodes) expect(node.isConnected).toBe(true)
+
+    // reload 的 settings.get 返回主进程顺序（固定模式不变）
+    deferNextRecentProjects = false
+    await act(async () => {
+      resolveRecentProjects?.({ settings: { recentProjects: ['/proj/A', '/proj/B', '/proj/C'] } })
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+    expect(rows().map((r) => r.textContent)).toEqual(ROWS_ABC)
+    for (const node of frameNodes) expect(node.isConnected).toBe(true)
+  })
+
+  it('does not show the previous workspace sessions under the new folder while loading', async () => {
+    useUIStore.setState({
+      currentWorkspace: '/proj/A',
+      sessions: [{ sessionId: 'a1', title: 'A的会话', updatedAt: 1, modelId: 'm' }],
+    })
+    const { container } = render(<ProjectSidebar onOpenProject={() => {}} openProjectLabel="打开" />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60))
+    })
+    // Real switch flow: activateWorkspace → setWorkspace clears the old session list
+    await act(async () => {
+      useUIStore.getState().setWorkspace('/proj/B')
+      await new Promise((resolve) => setTimeout(resolve, 60))
+    })
+    const trees = [...container.querySelectorAll('.sidebar-session-tree')].map((t) => t.textContent)
+    expect(trees[1] || '').not.toContain('A的会话')
+  })
+
+  it('shows the cached session list immediately on switch instead of 加载中 while re-fetching', async () => {
+    const { container } = render(<ProjectSidebar onOpenProject={() => {}} openProjectLabel="打开" />)
+    await act(async () => {
+      resolveRecentProjects?.({ settings: { recentProjects: ['/proj/A', '/proj/B', '/proj/C'] } })
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    // B 的会话已缓存（来自之前的访问）
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('pi-desktop:workspace-sessions', {
+          detail: { workspaceId: '/proj/B', sessions: [{ sessionId: 'b1', title: 'B的会话', updatedAt: 2, modelId: 'm' }] },
+        }),
+      )
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+
+    // 切换到 B，且本次重新拉取挂起（模拟真实 IPC 耗时）
+    deferNextSessionList = true
+    await act(async () => {
+      useUIStore.getState().setWorkspace('/proj/B')
+      // 等 rAF：currentWorkspace effect 展开 B 并开始重新拉取
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
+
+    const treeText = [...container.querySelectorAll('.sidebar-session-tree')].map((t) => t.textContent)
+    expect(treeText.join('')).not.toContain('加载中')
+    expect(treeText.join('')).toContain('B的会话')
+
+    // 放行重新拉取，列表仍稳定
+    await act(async () => {
+      resolveNextSessionList?.({
+        sessions: [{ sessionId: 'b1', title: 'B的会话', updatedAt: 2, modelId: 'm' }],
+      })
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+    const after = [...container.querySelectorAll('.sidebar-session-tree')].map((t) => t.textContent)
+    expect(after.join('')).not.toContain('加载中')
+    expect(after.join('')).toContain('B的会话')
+  })
+})

--- a/src/renderer/src/features/workspace/project-sidebar.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar.tsx
@@ -225,10 +225,14 @@ export function ProjectSidebar({
   const mergedSessionsByWorkspace = useMemo(() => {
     const next = { ...sessionsByWorkspace }
     if (currentWorkspace && !isSandboxPath(currentWorkspace)) {
-      // 缓存优先：切换工作区时 setWorkspace 会清空 store.sessions，
-      // 若直接覆盖会丢掉目标文件夹已缓存的会话列表（每次都重新“加载中”）。
-      // 仅当目标文件夹从未加载过（无缓存键）时才用 store.sessions 兜底。
-      if (!(currentWorkspace in next)) {
+      // store.sessions 是当前工作区的实时列表：新建 / fork / 删除都会更新它（不一定发布
+      // workspace-sessions 事件）。一旦实时列表非空就以它为准——否则新建/fork 的新会话会被
+      // 旧缓存遮蔽，侧栏一直显示旧列表直到手动刷新。
+      // 仅当切换工作区产生的瞬态空列表（setWorkspace 同步清空 sessions）且有缓存键时
+      // 才保留缓存，避免每次切换都闪“加载中”；空列表且无缓存则直接回填空列表。
+      if (sessions.length > 0) {
+        next[currentWorkspace] = sessions
+      } else if (!(currentWorkspace in next)) {
         next[currentWorkspace] = sessions
       }
     }

--- a/src/renderer/src/features/workspace/project-sidebar.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useUIStore } from '@renderer/stores/ui-store'
 import { ChevronRight, FolderOpen, Inbox, Plus } from '@renderer/components/icons'
@@ -18,6 +18,7 @@ import {
   type SandboxEntry,
   type SessionItem,
 } from './project-sidebar-types'
+import { projectFolderOrder } from './project-folder-order'
 import { ProjectDiskRow, ProjectSessionTree, SandboxDialogRow } from './project-sidebar-rows'
 
 export function ProjectSidebar({
@@ -38,6 +39,8 @@ export function ProjectSidebar({
   const [loadingSessionPaths, setLoadingSessionPaths] = useState<Set<string>>(() => new Set())
   const [sandboxes, setSandboxes] = useState<SandboxEntry[]>([])
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set())
+  const [recentProjectsFixedOrder, setRecentProjectsFixedOrder] = useState(false)
+  const fixedOrderRef = useRef(false)
   const [sectionOpen, setSectionOpen] = useState(true)
 
   const refreshSandboxes = useCallback(() => {
@@ -84,8 +87,7 @@ export function ProjectSidebar({
     return () => window.removeEventListener('pi-desktop:sandboxes-changed', onChanged)
   }, [refreshSandboxes])
 
-  useEffect(() => {
-    refreshSandboxes()
+  const reloadSidebarSettings = useCallback(() => {
     ipcClient
       .invoke('settings.get', { key: 'recentProjects' })
       .then((res) => {
@@ -94,13 +96,38 @@ export function ProjectSidebar({
           const diskOnly = list.filter((p) => !isSandboxPath(p))
           const merged = [...diskOnly]
           if (currentWorkspace && !isSandboxPath(currentWorkspace) && !merged.includes(currentWorkspace)) {
-            merged.unshift(currentWorkspace)
+            if (fixedOrderRef.current) merged.push(currentWorkspace)
+            else merged.unshift(currentWorkspace)
           }
           useUIStore.setState({ recentProjects: [...new Set(merged)].slice(0, 16) })
         }
       })
       .catch(() => {})
-  }, [refreshSandboxes, currentWorkspace])
+    ipcClient
+      .invoke('settings.get', { key: 'recentProjectsFixedOrder' })
+      .then((res) => {
+        const v = res?.settings?.recentProjectsFixedOrder === true
+        fixedOrderRef.current = v
+        setRecentProjectsFixedOrder(v)
+      })
+      .catch(() => {})
+  }, [currentWorkspace])
+
+  useEffect(() => {
+    refreshSandboxes()
+    reloadSidebarSettings()
+  }, [refreshSandboxes, reloadSidebarSettings])
+
+  useEffect(() => {
+    const onSettingsChanged = (event: Event) => {
+      const detail = (event as CustomEvent).detail as { key?: string } | undefined
+      if (!detail?.key || detail.key === 'recentProjects' || detail.key === 'recentProjectsFixedOrder') {
+        reloadSidebarSettings()
+      }
+    }
+    window.addEventListener('pi-desktop:settings-changed', onSettingsChanged)
+    return () => window.removeEventListener('pi-desktop:settings-changed', onSettingsChanged)
+  }, [reloadSidebarSettings])
 
   // Current project only on startup / workspace switch — never every recent project.
   useEffect(() => {
@@ -124,14 +151,11 @@ export function ProjectSidebar({
     return () => window.removeEventListener('pi-desktop:workspace-sessions', onWorkspaceSessions)
   }, [])
 
-  const diskPaths = (() => {
-    const set = new Set<string>()
-    if (currentWorkspace && !isSandboxPath(currentWorkspace)) set.add(currentWorkspace)
-    for (const p of recentProjects) {
-      if (!isSandboxPath(p)) set.add(p)
-    }
-    return [...set]
-  })()
+  const diskPaths = useMemo(() => {
+    const diskRecent = recentProjects.filter((p) => !isSandboxPath(p))
+    const diskCurrent = currentWorkspace && !isSandboxPath(currentWorkspace) ? currentWorkspace : null
+    return projectFolderOrder(diskRecent, diskCurrent, recentProjectsFixedOrder)
+  }, [recentProjects, currentWorkspace, recentProjectsFixedOrder])
 
   const switchDiskProject = async (path: string) => {
     if (path === currentWorkspace && !ephemeralSandboxDraft) return

--- a/src/renderer/src/features/workspace/project-sidebar.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar.tsx
@@ -99,7 +99,13 @@ export function ProjectSidebar({
             if (fixedOrderRef.current) merged.push(currentWorkspace)
             else merged.unshift(currentWorkspace)
           }
-          useUIStore.setState({ recentProjects: [...new Set(merged)].slice(0, 16) })
+          const next = [...new Set(merged)].slice(0, 16)
+          useUIStore.setState((state) => {
+            // 顺序/内容无变化时保持引用稳定，避免固定顺序下每次切换工作区都触发整个侧栏重渲染
+            const prev = state.recentProjects
+            if (prev.length === next.length && prev.every((p, i) => p === next[i])) return {}
+            return { recentProjects: next }
+          })
         }
       })
       .catch(() => {})
@@ -133,7 +139,10 @@ export function ProjectSidebar({
   useEffect(() => {
     if (!currentWorkspace || isSandboxPath(currentWorkspace)) return
     const frame = requestAnimationFrame(() => {
-      setExpandedPaths((previous) => new Set(previous).add(currentWorkspace))
+      setExpandedPaths((previous) => {
+        if (previous.has(currentWorkspace)) return previous
+        return new Set(previous).add(currentWorkspace)
+      })
       void loadWorkspaceSessions(currentWorkspace)
     })
     return () => cancelAnimationFrame(frame)
@@ -216,7 +225,12 @@ export function ProjectSidebar({
   const mergedSessionsByWorkspace = useMemo(() => {
     const next = { ...sessionsByWorkspace }
     if (currentWorkspace && !isSandboxPath(currentWorkspace)) {
-      next[currentWorkspace] = sessions
+      // 缓存优先：切换工作区时 setWorkspace 会清空 store.sessions，
+      // 若直接覆盖会丢掉目标文件夹已缓存的会话列表（每次都重新“加载中”）。
+      // 仅当目标文件夹从未加载过（无缓存键）时才用 store.sessions 兜底。
+      if (!(currentWorkspace in next)) {
+        next[currentWorkspace] = sessions
+      }
     }
     return next
   }, [sessionsByWorkspace, currentWorkspace, sessions])

--- a/src/renderer/src/lib/activate-workspace.test.ts
+++ b/src/renderer/src/lib/activate-workspace.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { activateWorkspace } from './activate-workspace'
+import { useUIStore } from '@renderer/stores/ui-store'
+
+const invokeMock = vi.hoisted(() =>
+  vi.fn(async (method: string) => {
+    if (method === 'workspace.open') return { ok: true }
+    if (method === 'session.list') return { sessions: [] }
+    if (method === 'settings.set') return { ok: true }
+    return {}
+  }),
+)
+
+vi.mock('@renderer/lib/ipc-client', () => ({ ipcClient: { invoke: (method: string) => invokeMock(method) } }))
+vi.mock('@renderer/lib/open-session', () => ({
+  openSessionIntoWorker: vi.fn(async () => {}),
+  openSessionPreview: vi.fn(async () => {}),
+}))
+vi.mock('@renderer/lib/session-shell', () => ({ focusSessionSync: vi.fn() }))
+vi.mock('@renderer/lib/capture-live-session-timeline', () => ({
+  captureVisibleLiveSessionTimeline: vi.fn(),
+}))
+vi.mock('@renderer/lib/session-worker-sync', () => ({ fetchWorkerLiveSnapshot: vi.fn(async () => {}) }))
+vi.mock('@renderer/lib/composer-run-display', () => ({ refreshComposerRunDisplay: vi.fn() }))
+vi.mock('@renderer/lib/workspace-session-choice', () => ({
+  chooseWorkspaceSession: vi.fn(() => undefined),
+}))
+vi.mock('@renderer/lib/session-navigation', () => ({
+  beginSessionNavigation: vi.fn(() => 1),
+  assertSessionNavigation: vi.fn(() => true),
+}))
+
+describe('activateWorkspace clears the stale session list on a real workspace switch', () => {
+  beforeEach(() => {
+    invokeMock.mockClear()
+    useUIStore.setState({
+      currentWorkspace: '/proj/A',
+      sessions: [{ sessionId: 'a1', title: 'A的会话', updatedAt: 1, modelId: 'm' }],
+    })
+  })
+
+  it('clears sessions synchronously when switching to another workspace', async () => {
+    const promise = activateWorkspace('/proj/B')
+    // 同步部分先执行：setWorkspace + 清空旧工作区 sessions（防止新文件夹树短暂显示旧会话）
+    expect(useUIStore.getState().currentWorkspace).toBe('/proj/B')
+    expect(useUIStore.getState().sessions).toEqual([])
+    await promise
+  })
+
+  it('keeps sessions when reactivating the same workspace', async () => {
+    const promise = activateWorkspace('/proj/A')
+    expect(useUIStore.getState().sessions).toHaveLength(1)
+    await promise
+  })
+})

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -57,6 +57,8 @@
     "langZh": "中文",
     "langEn": "English",
     "recentProjects": "Recent projects",
+    "fixedOrder": "Keep project order fixed",
+    "fixedOrderDesc": "Keep the project list order stable when opening projects (new ones append to the end); off = most recently used first (default)",
     "noRecentProjects": "No recent projects yet",
     "noRecentProjectsHint": "Open a workspace to see it here"
   },

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -57,6 +57,8 @@
     "langZh": "中文",
     "langEn": "English",
     "recentProjects": "最近项目",
+    "fixedOrder": "固定项目顺序",
+    "fixedOrderDesc": "打开项目时保持列表顺序不变（新项目追加到末尾）；关闭时按最近使用排序（默认）",
     "noRecentProjects": "暂无最近项目",
     "noRecentProjectsHint": "打开工作区后将出现在此"
   },

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -96,9 +96,8 @@ export const useUIStore = create<UIState>()(
         currentWorkspace: path,
         ephemeralSandboxDraft: false,
         pendingNewSessionPlaceholder: false,
-        recentProjects: path
-          ? [path, ...s.recentProjects.filter((p) => p !== path)].slice(0, 16)
-          : s.recentProjects,
+        // 不在此处重排 recentProjects：侧栏顺序以主进程配置为准（reloadSidebarSettings 同步），
+        // 此处 unshift 会让固定顺序模式下列表先跳顶再弹回（闪烁），MRU 模式也由磁盘路径列表当前置顶兜底。
         ...(changed
           ? {
             sessions: [],


### PR DESCRIPTION
## 用户场景 / 问题
1. 侧栏项目列表按 MRU 排序，每次切换项目列表就重排，想固定顺序的用户找不到项目。
2. 即使不开固定顺序，切换项目时列表也会"先跳一下再弹回来"，每次切换都可见闪烁。

## 代码问题
闪烁根因：`ui-store.setWorkspace` 会把当前工作区 unshift 到 `recentProjects` 最前（renderer 本地先改一次），随后 `reloadSidebarSettings` 又从主进程拉回真实顺序——先跳再弹回。另外顺序无变化时也换了数组引用，导致整个侧栏无谓重渲染。

## 修复方案（2 个提交）
1. 新增配置 `recentProjectsFixedOrder`（默认 false 保持 MRU）：开启后已有项目不移动、新项目追加末尾、当前项目仅高亮不置顶。纯函数拆到 `recent-projects.ts` / `project-folder-order.ts` 并带测试；设置页开关即时生效。
2. `setWorkspace` 不再重排 `recentProjects`（顺序以主进程配置为唯一事实源，MRU 显示由 `projectFolderOrder` 的"当前置顶"规则兜底）；`reloadSidebarSettings` 顺序不变时保持数组引用稳定。