### PR TITLE
perf(session): read session header without loading the whole transcript

### DIFF
--- a/src/main/__tests__/session-file-meta.test.ts
+++ b/src/main/__tests__/session-file-meta.test.ts
@@ -34,4 +34,28 @@ describe('session file metadata', () => {
       cwd: join(directory, 'workspace-b'),
     })
   })
+
+  it('should_read_header_even_when_preceded_by_blank_lines', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'pi-session-meta-'))
+    temporaryDirectories.push(directory)
+    const sessionFile = join(directory, 'session.jsonl')
+    writeFileSync(
+      sessionFile,
+      `\n\n${JSON.stringify({ type: 'session', id: 'session-2', cwd: '/tmp/ws' })}\n`,
+      'utf8',
+    )
+
+    expect(readSessionMetaFromFile(sessionFile)).toEqual({ sessionId: 'session-2', cwd: '/tmp/ws' })
+  })
+
+  it('should_read_header_from_a_large_transcript_without_needing_the_tail', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'pi-session-meta-'))
+    temporaryDirectories.push(directory)
+    const sessionFile = join(directory, 'session.jsonl')
+    const header = `${JSON.stringify({ type: 'session', id: 'session-3', cwd: '/tmp/ws' })}\n`
+    const bigEntry = `${JSON.stringify({ type: 'message', text: 'x'.repeat(1024) })}\n`
+    writeFileSync(sessionFile, header + bigEntry.repeat(4096), 'utf8')
+
+    expect(readSessionMetaFromFile(sessionFile)).toEqual({ sessionId: 'session-3', cwd: '/tmp/ws' })
+  })
 })

--- a/src/main/session-file-meta.ts
+++ b/src/main/session-file-meta.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs'
+import { closeSync, existsSync, openSync, readSync } from 'fs'
 
 export type SessionFileMeta = {
   sessionId: string
@@ -7,10 +7,27 @@ export type SessionFileMeta = {
 
 export function readSessionMetaFromFile(sessionFile: string): SessionFileMeta | null {
   if (!sessionFile || !existsSync(sessionFile)) return null
+  let fd: number | null = null
   try {
-    const firstLine = readFileSync(sessionFile, 'utf-8')
-      .split('\n')
-      .find((line) => line.trim())
+    // Session JSONL can be large. Metadata lives in its first non-empty line, so
+    // never synchronously read/split the whole transcript on an IPC hot path.
+    fd = openSync(sessionFile, 'r')
+    const cap = 64 * 1024
+    const chunks: Buffer[] = []
+    const scratch = Buffer.allocUnsafe(4 * 1024)
+    let total = 0
+    let raw = ''
+    while (total < cap) {
+      const bytesRead = readSync(fd, scratch, 0, Math.min(scratch.length, cap - total), total)
+      if (bytesRead === 0) break
+      chunks.push(Buffer.from(scratch.subarray(0, bytesRead)))
+      total += bytesRead
+      raw = Buffer.concat(chunks, total).toString('utf8')
+      // Stop once the buffered prefix contains a complete non-empty line; a bare
+      // newline is not enough (the file may start with blank lines).
+      if (/\S[^\n]*\n/.test(raw)) break
+    }
+    const firstLine = raw.split(/\r?\n/).find((line) => line.trim())?.trim() ?? ''
     if (!firstLine) return null
     const header = JSON.parse(firstLine) as {
       type?: string
@@ -25,6 +42,14 @@ export function readSessionMetaFromFile(sessionFile: string): SessionFileMeta | 
     }
   } catch {
     return null
+  } finally {
+    if (fd != null) {
+      try {
+        closeSync(fd)
+      } catch {
+        /* ignore */
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 用户场景 / 问题
项目会话多、单个会话 JSONL 很大（长对话可达数十 MB）时，侧栏列表加载和会话元信息读取明显变慢——只为了取 sessionId/header 却把整个文件读进内存。

## 代码问题
`readSessionIdFromFile` 用 `readFile` 全量读入再取首行。

## 修复方案
改为流式读取：按块读到第一个换行即停，正确处理文件开头的空行（跳过空行继续找首个非空行，而不是误判截断）。补了 2 个测试：空行前缀、大文件只读头部。