### PR TITLE
feat(model): fetch gateway model catalog + auto-register with reasoning enabled

### DIFF
--- a/src/main/ipc/handlers/model-runtime.test.ts
+++ b/src/main/ipc/handlers/model-runtime.test.ts
@@ -16,6 +16,13 @@ vi.mock('../registry', () => ({
   registerHandler: (channel: string, handler: (request: Record<string, unknown>) => Promise<unknown>) => {
     mocks.handlers.set(channel, handler)
   },
+  registerHandlerWithSchema: (
+    channel: string,
+    _schema: unknown,
+    handler: (request: Record<string, unknown>) => Promise<unknown>,
+  ) => {
+    mocks.handlers.set(channel, handler)
+  },
 }))
 
 vi.mock('../../pi-models-json', () => ({

--- a/src/main/ipc/handlers/model-runtime.test.ts
+++ b/src/main/ipc/handlers/model-runtime.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, (request: Record<string, unknown>) => Promise<unknown>>(),
+  readModelsConfigRaw: vi.fn(),
+  fetchRemoteModelsCached: vi.fn(),
+  updateModelsConfigLight: vi.fn(),
+  reloadModels: vi.fn(),
+  workerRunning: true,
+  setModel: vi.fn(),
+  resolveAvailableModels: vi.fn(),
+  resolveCatalogModels: vi.fn(),
+}))
+
+vi.mock('../registry', () => ({
+  registerHandler: (channel: string, handler: (request: Record<string, unknown>) => Promise<unknown>) => {
+    mocks.handlers.set(channel, handler)
+  },
+}))
+
+vi.mock('../../pi-models-json', () => ({
+  readModelsConfigRaw: mocks.readModelsConfigRaw,
+  modelsCatalogFromConfig: vi.fn((config: { providers: Record<string, unknown> }) => {
+    const out: Array<{ id: string; name: string; provider: string }> = []
+    for (const [provider, prov] of Object.entries(config.providers || {})) {
+      for (const model of (prov as { models?: { id?: string }[] }).models || []) {
+        if (model.id) out.push({ id: model.id, name: model.id, provider })
+      }
+    }
+    return out
+  }),
+  fetchRemoteModelsCached: mocks.fetchRemoteModelsCached,
+  updateModelsConfigLight: mocks.updateModelsConfigLight,
+}))
+
+vi.mock('../../worker-manager', () => ({
+  workerManager: {
+    get isRunning() {
+      return mocks.workerRunning
+    },
+    cwd: '/project',
+    reloadModels: mocks.reloadModels,
+    setModel: mocks.setModel,
+    hasActiveTurns: false,
+  },
+}))
+
+vi.mock('../../config-store', () => ({ configStore: { get: vi.fn(() => '') } }))
+vi.mock('../../sandbox-workspaces', () => ({ isSandboxWorkspacePath: vi.fn(() => false) }))
+vi.mock('../sdk-session', () => ({ getActiveSdkModule: vi.fn() }))
+vi.mock('../../active-sdk-models', () => ({
+  listAvailableModelsWithSdk: vi.fn(async () => []),
+  listCatalogModelsWithSdk: vi.fn(async () => []),
+  resolveAvailableModels: mocks.resolveAvailableModels,
+  resolveCatalogModels: mocks.resolveCatalogModels,
+}))
+
+import { registerModelRuntimeHandlers } from './model-runtime'
+
+const gatewayConfig = {
+  providers: {
+    acme: {
+      baseUrl: 'https://ai-gateway.example/v1',
+      api: 'openai-completions',
+      apiKey: 'acme-key',
+    },
+  },
+}
+
+beforeEach(() => {
+  mocks.handlers.clear()
+  mocks.readModelsConfigRaw.mockReset().mockReturnValue({ config: gatewayConfig })
+  mocks.fetchRemoteModelsCached.mockReset()
+  mocks.updateModelsConfigLight.mockReset().mockImplementation(async (apply: (current: Record<string, unknown>) => Record<string, unknown>) => {
+    const current = mocks.readModelsConfigRaw().config
+    const next = apply(current as never)
+    return { ok: true, path: '~/.pi/agent/models.json', changed: next !== current }
+  })
+  mocks.reloadModels.mockReset().mockResolvedValue(undefined)
+  mocks.setModel.mockReset().mockResolvedValue('acme/Hy3')
+  mocks.resolveAvailableModels.mockReset()
+  mocks.resolveCatalogModels.mockReset()
+  mocks.workerRunning = true
+  registerModelRuntimeHandlers()
+})
+
+describe('model.list remote merge', () => {
+  it('fetches gateway chat models when worker and sdk lists are empty', async () => {
+    mocks.resolveAvailableModels.mockResolvedValue([])
+    mocks.fetchRemoteModelsCached.mockResolvedValue({
+      ok: true,
+      models: [
+        { id: 'Hy3', name: 'Hy3', modelType: 'chat' },
+        { id: 'claude-sonnet-5', name: 'claude-sonnet-5', modelType: 'chat' },
+        { id: 'Banana-1', name: 'Banana-1', modelType: 'image' },
+        { id: 'Hailuo-02', name: 'Hailuo-02', modelType: 'video' },
+      ],
+    })
+
+    const response = await mocks.handlers.get('ipc:model.list')!({ scope: 'available' })
+
+    expect(mocks.fetchRemoteModelsCached).toHaveBeenCalledWith(
+      { baseUrl: 'https://ai-gateway.example/v1', apiKey: 'acme-key', authHeader: undefined },
+      { timeoutMs: 4000 },
+    )
+    expect(response).toEqual({
+      models: [
+        expect.objectContaining({ id: 'Hy3', provider: 'acme', available: true }),
+        expect.objectContaining({ id: 'claude-sonnet-5', provider: 'acme', available: true }),
+      ],
+    })
+    expect((response as { models: Array<{ id: string }> }).models.map((m) => m.id)).not.toContain('Banana-1')
+  })
+
+  it('merges remote models even when the worker already returns local models', async () => {
+    mocks.resolveAvailableModels.mockResolvedValue([
+      { id: 'Hy3', name: 'Hy3', provider: 'acme', contextWindow: 128000, maxOutput: 4096, available: true },
+    ])
+    mocks.fetchRemoteModelsCached.mockResolvedValue({
+      ok: true,
+      models: [
+        { id: 'Hy3', name: 'Hy3', modelType: 'chat' },
+        { id: 'claude-sonnet-5', name: 'claude-sonnet-5', modelType: 'chat' },
+      ],
+    })
+
+    const response = await mocks.handlers.get('ipc:model.list')!({ scope: 'available' })
+
+    expect(mocks.fetchRemoteModelsCached).toHaveBeenCalledOnce()
+    // 本地条目优先（保留 contextWindow），远程补充未声明的 claude-sonnet-5
+    expect(response).toEqual({
+      models: [
+        { id: 'Hy3', name: 'Hy3', provider: 'acme', contextWindow: 128000, maxOutput: 4096, available: true },
+        { id: 'claude-sonnet-5', name: 'claude-sonnet-5', provider: 'acme', contextWindow: 0, maxOutput: 0, available: true },
+      ],
+    })
+  })
+
+  it('returns local models when the gateway fetch fails', async () => {
+    mocks.resolveAvailableModels.mockResolvedValue([
+      { id: 'gpt-4o', name: 'gpt-4o', provider: 'openai', contextWindow: 128000, maxOutput: 4096, available: true },
+    ])
+    mocks.fetchRemoteModelsCached.mockResolvedValue({ ok: false, error: 'HTTP 401' })
+
+    const response = await mocks.handlers.get('ipc:model.list')!({ scope: 'available' })
+
+    expect(response).toEqual({ models: [{ id: 'gpt-4o', name: 'gpt-4o', provider: 'openai', contextWindow: 128000, maxOutput: 4096, available: true }] })
+  })
+
+  it('returns empty when everything fails', async () => {
+    mocks.resolveAvailableModels.mockResolvedValue([])
+    mocks.fetchRemoteModelsCached.mockResolvedValue({ ok: false, error: 'HTTP 401' })
+
+    const response = await mocks.handlers.get('ipc:model.list')!({ scope: 'available' })
+
+    expect(response).toEqual({ models: [] })
+  })
+})
+
+describe('model.set auto-register', () => {
+  it('writes a minimal model entry and reloads before setting a fetched model', async () => {
+    let applied: Record<string, unknown> | undefined
+    mocks.updateModelsConfigLight.mockImplementation(async (apply) => {
+      const current = mocks.readModelsConfigRaw().config
+      const next = apply(current as never)
+      applied = next as Record<string, unknown>
+      return { ok: true, path: '~/.pi/agent/models.json', changed: next !== current }
+    })
+
+    const response = await mocks.handlers.get('ipc:model.set')!({
+      provider: 'acme',
+      modelId: 'Hy3',
+      sessionFile: '/project/sessions/abc.session.json',
+    })
+
+    expect(applied).toMatchObject({
+      providers: {
+        acme: {
+          baseUrl: 'https://ai-gateway.example/v1',
+          models: [expect.objectContaining({ id: 'Hy3', input: ['text'] })],
+        },
+      },
+    })
+    expect(mocks.reloadModels).toHaveBeenCalledOnce()
+    expect(mocks.setModel).toHaveBeenCalledWith('acme', 'Hy3', '/project/sessions/abc.session.json')
+    expect(response).toEqual({ modelId: 'acme/Hy3' })
+  })
+
+  it('skips auto-register when the model is already declared', async () => {
+    mocks.readModelsConfigRaw.mockReturnValue({
+      config: {
+        providers: {
+          acme: { baseUrl: 'https://ai-gateway.example/v1', api: 'openai-completions', models: [{ id: 'Hy3' }] },
+        },
+      },
+    })
+
+    await mocks.handlers.get('ipc:model.set')!({ provider: 'acme', modelId: 'Hy3', sessionFile: '/x.session.json' })
+
+    expect(mocks.reloadModels).not.toHaveBeenCalled()
+    expect(mocks.setModel).toHaveBeenCalledOnce()
+  })
+
+  it('skips auto-register for providers not configured in models.json', async () => {
+    mocks.readModelsConfigRaw.mockReturnValue({ config: { providers: {} } })
+
+    await mocks.handlers.get('ipc:model.set')!({ provider: 'anthropic', modelId: 'claude-sonnet-5' })
+
+    expect(mocks.reloadModels).not.toHaveBeenCalled()
+    expect(mocks.setModel).toHaveBeenCalledWith('anthropic', 'claude-sonnet-5', undefined)
+  })
+})

--- a/src/main/ipc/handlers/model-runtime.test.ts
+++ b/src/main/ipc/handlers/model-runtime.test.ts
@@ -158,7 +158,7 @@ describe('model.list remote merge', () => {
 })
 
 describe('model.set auto-register', () => {
-  it('writes a minimal model entry and reloads before setting a fetched model', async () => {
+  it('writes a chat model entry with reasoning enabled and reloads before setting a fetched model', async () => {
     let applied: Record<string, unknown> | undefined
     mocks.updateModelsConfigLight.mockImplementation(async (apply) => {
       const current = mocks.readModelsConfigRaw().config
@@ -177,7 +177,7 @@ describe('model.set auto-register', () => {
       providers: {
         acme: {
           baseUrl: 'https://ai-gateway.example/v1',
-          models: [expect.objectContaining({ id: 'Hy3', input: ['text'] })],
+          models: [expect.objectContaining({ id: 'Hy3', input: ['text'], reasoning: true })],
         },
       },
     })

--- a/src/main/ipc/handlers/model-runtime.ts
+++ b/src/main/ipc/handlers/model-runtime.ts
@@ -115,13 +115,18 @@ async function ensureModelDeclaredInConfig(provider: string, modelId: string): P
     const prov = current.providers?.[provider]
     if (!prov || !prov.baseUrl) return current
     if ((prov.models || []).some((m) => m?.id === modelId)) return current
+    // 聊天模型默认声明支持扩展思考：否则 pi 会把该模型当作不支持 reasoning，
+    // 将用户设置的 thinking level 静默钳制成 off（网关目录本身不声明此能力）。
     return {
       ...current,
       providers: {
         ...current.providers,
         [provider]: {
           ...prov,
-          models: [...(prov.models || []), { id: modelId, name: modelId, input: ['text'] }],
+          models: [
+            ...(prov.models || []),
+            { id: modelId, name: modelId, input: ['text'], reasoning: true },
+          ],
         },
       },
     }

--- a/src/main/ipc/handlers/model-runtime.ts
+++ b/src/main/ipc/handlers/model-runtime.ts
@@ -3,7 +3,12 @@ import { registerHandler, registerHandlerWithSchema } from '../registry'
 import { workerManager } from '../../worker-manager'
 import { configStore } from '../../config-store'
 import { isSandboxWorkspacePath } from '../../sandbox-workspaces'
-import { readModelsConfigRaw, modelsCatalogFromConfig } from '../../pi-models-json'
+import {
+  readModelsConfigRaw,
+  modelsCatalogFromConfig,
+  fetchRemoteModelsCached,
+  updateModelsConfigLight,
+} from '../../pi-models-json'
 import { getActiveSdkModule } from '../sdk-session'
 import { getSessionContextPreviewFromDisk } from '../../session-context-preview'
 import { getSessionLeafOverride } from '../../session-leaf-override'
@@ -16,7 +21,145 @@ import {
   listCatalogModelsWithSdk,
   resolveAvailableModels,
   resolveCatalogModels,
+  type ModelEntry,
 } from '../../active-sdk-models'
+
+type ModelRow = {
+  id: string
+  name: string
+  provider?: string
+  contextWindow: number
+  maxOutput: number
+  available: boolean
+}
+
+function mapRegistry(
+  models: readonly {
+    id: string
+    name?: string
+    provider?: string
+    contextWindow?: number
+    maxOutput?: number
+    maxTokens?: number
+  }[],
+): ModelRow[] {
+  return models.map((m) => ({
+    id: m.id,
+    name: m.name || m.id,
+    provider: m.provider,
+    contextWindow: m.contextWindow || 0,
+    maxOutput: m.maxOutput || m.maxTokens || 0,
+    available: true,
+  }))
+}
+
+/** 明确不是对话/文本生成的类型（网关可能把图片/视频/3D/音频模型也列在 /v1/models 里）。 */
+const NON_CHAT_MODEL_TYPES = new Set([
+  'image',
+  'imagegen',
+  'image-gen',
+  'video',
+  'videogen',
+  'video-gen',
+  'audio',
+  'tts',
+  'stt',
+  'speech',
+  'embedding',
+  'rerank',
+  'moderation',
+  '3d',
+  '3d-model',
+  // 部分网关用 model_type: "model" 标记 3D 生成模型
+  'model',
+])
+
+/**
+ * 从 models.json 里配置了 baseUrl 的服务商拉取 /v1/models 目录（带 TTL 缓存），
+ * 过滤掉明确的非对话类型，与本地/SDK 解析结果合并后展示给模型选择器。
+ */
+async function remoteCatalogModels(): Promise<ModelRow[]> {
+  const { config } = readModelsConfigRaw()
+  const rows: ModelRow[] = []
+  await Promise.allSettled(
+    Object.entries(config.providers || {}).map(async ([provider, p]) => {
+      if (!p?.baseUrl) return
+      const r = await fetchRemoteModelsCached(
+        { baseUrl: p.baseUrl, apiKey: p.apiKey, authHeader: p.authHeader },
+        { timeoutMs: 4_000 },
+      )
+      if (!r.ok) return
+      for (const m of r.models) {
+        if (m.modelType && NON_CHAT_MODEL_TYPES.has(m.modelType.toLowerCase())) continue
+        rows.push({
+          id: m.id,
+          name: m.name || m.id,
+          provider,
+          contextWindow: 0,
+          maxOutput: 0,
+          available: true,
+        })
+      }
+    }),
+  )
+  return rows
+}
+
+/**
+ * 选中模型时若该 provider 已配置 baseUrl 但模型未声明，自动写入最小模型条目并重载，
+ * 让网关拉取到的模型可以真正被会话使用。写入走轻量 update（无 SDK 校验/import，
+ * 串行队列内基于磁盘最新状态追加），避免切换模型时卡顿。
+ */
+async function ensureModelDeclaredInConfig(provider: string, modelId: string): Promise<void> {
+  const r = await updateModelsConfigLight((current) => {
+    const prov = current.providers?.[provider]
+    if (!prov || !prov.baseUrl) return current
+    if ((prov.models || []).some((m) => m?.id === modelId)) return current
+    return {
+      ...current,
+      providers: {
+        ...current.providers,
+        [provider]: {
+          ...prov,
+          models: [...(prov.models || []), { id: modelId, name: modelId, input: ['text'] }],
+        },
+      },
+    }
+  })
+  if (!r.ok) {
+    console.warn('[IPC] model.set auto-register failed:', r.error)
+    return
+  }
+  if (!r.changed) return
+  try {
+    await workerManager.reloadModels()
+  } catch (e) {
+    console.error('[IPC] model.set reloadModels failed:', e)
+  }
+}
+
+/**
+ * 合并本地/SDK 解析结果与远程网关目录：同一 provider+id 以本地为准（保留完整配置），
+ * 远程补充未声明的模型。本地信息优先，远程不覆盖。
+ */
+function mergeModelRows(local: readonly ModelEntry[], remote: readonly ModelRow[]): ModelRow[] {
+  const byKey = new Map<string, ModelRow>()
+  for (const m of local) {
+    byKey.set(`${m.provider}:${m.id}`, {
+      id: m.id,
+      name: m.name || m.id,
+      provider: m.provider,
+      contextWindow: m.contextWindow || 0,
+      maxOutput: m.maxOutput || m.maxTokens || 0,
+      available: true,
+    })
+  }
+  for (const m of remote) {
+    const key = `${m.provider}:${m.id}`
+    if (!byKey.has(key)) byKey.set(key, m)
+  }
+  return [...byKey.values()]
+}
 
 export function registerModelRuntimeHandlers(): void {
   registerHandler('ipc:model.list', async (req) => {
@@ -35,7 +178,7 @@ export function registerModelRuntimeHandlers(): void {
 
     const catalogFromDisk = () => {
       const { config, parseError } = readModelsConfigRaw()
-      if (parseError) return { models: [] as ReturnType<typeof mapRegistry> }
+      if (parseError) return { models: [] as ModelRow[] }
       return { models: modelsCatalogFromConfig(config) }
     }
 
@@ -71,7 +214,7 @@ export function registerModelRuntimeHandlers(): void {
         catalog: () => catalogFromDisk().models,
         onSdkError: (error) => console.error('[IPC] model.list catalog failed:', error),
       })
-      return { models }
+      return { models: mergeModelRows(models, await remoteCatalogModels()) }
     }
 
     const models = await resolveAvailableModels({
@@ -87,7 +230,7 @@ export function registerModelRuntimeHandlers(): void {
       onWorkerError: (error) => console.error('[IPC] model.list worker failed:', error),
       onSdkError: (error) => console.error('[IPC] model.list failed:', error),
     })
-    return { models }
+    return { models: mergeModelRows(models, await remoteCatalogModels()) }
   })
 
   registerHandler('ipc:model.set', async (req) => {
@@ -108,6 +251,8 @@ export function registerModelRuntimeHandlers(): void {
         modelId = raw
       }
     }
+    // 网关拉取到的模型可能尚未写入 models.json：先自动注册再设置，避免 MODEL_NOT_FOUND
+    await ensureModelDeclaredInConfig(provider, modelId)
     if (!workerManager.isRunning && !sessionFile) {
       const cwd = workerManager.cwd || configStore.get('currentProject')
       if (!cwd || isSandboxWorkspacePath(cwd)) throw new Error('Worker not started')

--- a/src/main/ipc/handlers/model-runtime.ts
+++ b/src/main/ipc/handlers/model-runtime.ts
@@ -21,7 +21,6 @@ import {
   listCatalogModelsWithSdk,
   resolveAvailableModels,
   resolveCatalogModels,
-  type ModelEntry,
 } from '../../active-sdk-models'
 
 type ModelRow = {
@@ -31,6 +30,8 @@ type ModelRow = {
   contextWindow: number
   maxOutput: number
   available: boolean
+  managedBy?: string
+  auth?: { supported?: boolean; configured?: boolean }
 }
 
 function mapRegistry(
@@ -110,7 +111,7 @@ async function remoteCatalogModels(): Promise<ModelRow[]> {
  * 让网关拉取到的模型可以真正被会话使用。写入走轻量 update（无 SDK 校验/import，
  * 串行队列内基于磁盘最新状态追加），避免切换模型时卡顿。
  */
-async function ensureModelDeclaredInConfig(provider: string, modelId: string): Promise<void> {
+async function ensureModelDeclaredInConfig(provider: string, modelId: string, sessionFile?: string): Promise<void> {
   const r = await updateModelsConfigLight((current) => {
     const prov = current.providers?.[provider]
     if (!prov || !prov.baseUrl) return current
@@ -137,7 +138,9 @@ async function ensureModelDeclaredInConfig(provider: string, modelId: string): P
   }
   if (!r.changed) return
   try {
-    await workerManager.reloadModels()
+    // 目标会话可能绑定在后台 worker slot：刷新必须按 sessionFile 路由，
+    // 否则 foreground 拿到新模型而目标 slot 仍是旧配置 → MODEL_NOT_FOUND
+    await workerManager.reloadModels(sessionFile)
   } catch (e) {
     console.error('[IPC] model.set reloadModels failed:', e)
   }
@@ -150,14 +153,19 @@ async function ensureModelDeclaredInConfig(provider: string, modelId: string): P
 function mergeModelRows(local: readonly ModelEntry[], remote: readonly ModelRow[]): ModelRow[] {
   const byKey = new Map<string, ModelRow>()
   for (const m of local) {
-    byKey.set(`${m.provider}:${m.id}`, {
+    const row: ModelRow = {
       id: m.id,
       name: m.name || m.id,
       provider: m.provider,
       contextWindow: m.contextWindow || 0,
       maxOutput: m.maxOutput || m.maxTokens || 0,
-      available: true,
-    })
+      available: m.available ?? true,
+    }
+    // settings scope 由 mapRegistry 提供鉴权/归属信息，合并远程模型时必须保留；
+    // catalog 等 scope 不携带这些字段，保持原样（不输出多余键）。
+    if (m.managedBy !== undefined) row.managedBy = m.managedBy
+    if (m.auth !== undefined) row.auth = m.auth
+    byKey.set(`${m.provider}:${m.id}`, row)
   }
   for (const m of remote) {
     const key = `${m.provider}:${m.id}`
@@ -183,7 +191,7 @@ export function registerModelRuntimeHandlers(): void {
 
     const catalogFromDisk = () => {
       const { config, parseError } = readModelsConfigRaw()
-      if (parseError) return { models: [] as ModelRow[] }
+      if (parseError) return { models: [] as ModelEntry[] }
       return { models: modelsCatalogFromConfig(config) }
     }
 
@@ -257,7 +265,7 @@ export function registerModelRuntimeHandlers(): void {
       }
     }
     // 网关拉取到的模型可能尚未写入 models.json：先自动注册再设置，避免 MODEL_NOT_FOUND
-    await ensureModelDeclaredInConfig(provider, modelId)
+    await ensureModelDeclaredInConfig(provider, modelId, sessionFile)
     if (!workerManager.isRunning && !sessionFile) {
       const cwd = workerManager.cwd || configStore.get('currentProject')
       if (!cwd || isSandboxWorkspacePath(cwd)) throw new Error('Worker not started')

--- a/src/main/pi-models-json.test.ts
+++ b/src/main/pi-models-json.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs'
-import { tmpdir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {

--- a/src/main/pi-models-json.test.ts
+++ b/src/main/pi-models-json.test.ts
@@ -5,6 +5,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   readModelsConfigWithSdk,
   writeModelsConfigWithSdk,
+  fetchRemoteModels,
+  fetchRemoteModelsCached,
+  clearRemoteModelCatalogCache,
+  updateModelsConfigLight,
+  readModelsConfigRaw,
+  getModelsJsonPath,
   type PiModelsConfig,
 } from './pi-models-json'
 
@@ -300,5 +306,131 @@ describe('active SDK model config persistence', () => {
     } finally {
       warn.mockRestore()
     }
+  })
+})
+
+describe('updateModelsConfigLight', () => {
+  const appendModel = (provider: string, modelId: string) => (current: PiModelsConfig) => {
+    const prov = current.providers?.[provider]
+    if (!prov) return current
+    if ((prov.models || []).some((m) => m?.id === modelId)) return current
+    return {
+      ...current,
+      providers: {
+        ...current.providers,
+        [provider]: { ...prov, models: [...(prov.models || []), { id: modelId }] },
+      },
+    }
+  }
+
+  it('writes without SDK validation and preserves unknown fields via retention', async () => {
+    const agentDir = createAgentDir()
+    // 写入一个带未知字段的原始文件，验证 light 写入保留
+    const p = getModelsJsonPath(agentDir)
+    writeFileSync(p, JSON.stringify({ $schema: './schema.json', providers: { a: { baseUrl: 'https://x/v1' } } }), 'utf-8')
+    const r = await updateModelsConfigLight(appendModel('a', 'm1'), agentDir)
+    expect(r.ok && r.changed).toBe(true)
+    const raw = JSON.parse(readFileSync(p, 'utf-8'))
+    expect(raw.$schema).toBe('./schema.json')
+    expect(raw.providers.a.models).toEqual([{ id: 'm1' }])
+  })
+
+  it('serializes concurrent appends so each model survives', async () => {
+    const agentDir = createAgentDir()
+    writeFileSync(getModelsJsonPath(agentDir), JSON.stringify({ providers: { a: { baseUrl: 'https://x/v1' } } }), 'utf-8')
+    const [r1, r2] = await Promise.all([
+      updateModelsConfigLight(appendModel('a', 'm1'), agentDir),
+      updateModelsConfigLight(appendModel('a', 'm2'), agentDir),
+    ])
+    expect(r1.ok && r2.ok).toBe(true)
+    const raw = JSON.parse(readFileSync(getModelsJsonPath(agentDir), 'utf-8'))
+    expect(raw.providers.a.models.map((m: { id: string }) => m.id).sort()).toEqual(['m1', 'm2'])
+  })
+
+  it('reports changed=false when nothing is modified', async () => {
+    const agentDir = createAgentDir()
+    writeFileSync(
+      getModelsJsonPath(agentDir),
+      JSON.stringify({ providers: { a: { baseUrl: 'https://x/v1', models: [{ id: 'm1' }] } } }),
+      'utf-8',
+    )
+    const r = await updateModelsConfigLight(appendModel('a', 'm1'), agentDir)
+    expect(r).toMatchObject({ ok: true, changed: false })
+  })
+
+  it('leaves no tmp files behind', async () => {
+    const agentDir = createAgentDir()
+    await updateModelsConfigLight(appendModel('a', 'm1'), agentDir)
+    expect(readdirSync(agentDir).filter((f) => f.endsWith('.tmp'))).toEqual([])
+  })
+})
+
+describe('remote model catalog fetch', () => {
+  const originalFetch = globalThis.fetch
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    clearRemoteModelCatalogCache()
+  })
+
+  it('captures model ids and type info from OpenAI-compatible responses', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            { id: 'chat-a', model_type: 'chat' },
+            { id: 'img-b', model_type: 'image' },
+            { id: 'no-type' },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const result = await fetchRemoteModels({ baseUrl: 'https://gateway.example/v1', apiKey: 'secret-key' })
+    expect(result).toEqual({
+      ok: true,
+      models: [
+        { id: 'chat-a', name: 'chat-a', modelType: 'chat' },
+        { id: 'img-b', name: 'img-b', modelType: 'image' },
+        { id: 'no-type', name: 'no-type', modelType: undefined },
+      ],
+    })
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://gateway.example/v1/models',
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer secret-key' }) }),
+    )
+  })
+
+  it('appends /v1/models when baseUrl has no version segment', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ models: [{ id: 'm1', name: 'M1' }] }), { status: 200 }),
+    )
+    const result = await fetchRemoteModels({ baseUrl: 'https://gateway.example' })
+    expect(result.ok && result.models.map((m) => m.id)).toEqual(['m1'])
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://gateway.example/v1/models',
+      expect.anything(),
+    )
+  })
+
+  it('caches successful catalogs per baseUrl until TTL', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ data: [{ id: 'cached-model' }] }), { status: 200 }),
+    )
+
+    const first = await fetchRemoteModelsCached({ baseUrl: 'https://gateway.example/v1' })
+    const second = await fetchRemoteModelsCached({ baseUrl: 'https://gateway.example/v1' })
+    expect(first.ok && second.ok).toBe(true)
+    if (first.ok && second.ok) expect(first.models).toEqual(second.models)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache failed fetches', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('nope', { status: 500 }))
+    const first = await fetchRemoteModelsCached({ baseUrl: 'https://gateway.example/v1' })
+    const second = await fetchRemoteModelsCached({ baseUrl: 'https://gateway.example/v1' })
+    expect(first.ok).toBe(false)
+    expect(second.ok).toBe(false)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/pi-models-json.ts
+++ b/src/main/pi-models-json.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs'
+import { mkdir, rename, rm, writeFile } from 'fs/promises'
 import { dirname, join } from 'path'
 import { app } from 'electron'
 import { pathToFileURL } from 'node:url'
@@ -255,6 +256,65 @@ export async function writeModelsConfig(config: PiModelsConfig): Promise<{ ok: b
   return writeModelsConfigWithSdk(config, sdk, agentDir)
 }
 
+let lightWriteChain: Promise<unknown> = Promise.resolve()
+
+/**
+ * 轻量更新 models.json：在串行写入点内读取磁盘最新配置，应用 apply 变更后
+ * 原子写盘（异步 fs），不做 SDK 校验。用于低风险的自动注册（如 model.set 兜底
+ * 追加网关拉取到的模型），避免触发全局 SDK 动态 import（冷启动实测 ~1s）与
+ * ModelRuntime 校验开销；串行队列 + 基于磁盘最新状态的变更保证并发追加不丢条目。
+ */
+export function updateModelsConfigLight(
+  apply: (current: PiModelsConfig) => PiModelsConfig,
+  agentDir = join(homedir(), '.pi', 'agent'),
+): Promise<
+  | { ok: true; path: string; changed: boolean }
+  | { ok: false; error: string; path: string }
+> {
+  const path = getModelsJsonPath(agentDir)
+  const run = async () => {
+    try {
+      const current = readModelsConfigRaw(path).config
+      const next = apply(current)
+      if (next === current) return { ok: true as const, path, changed: false }
+      let retainedRoot: Record<string, unknown> | null
+      try {
+        retainedRoot = readRetainedModelsConfig(path)
+      } catch (error: unknown) {
+        return {
+          ok: false as const,
+          error: `原 models.json 无法解析，未写入: ${(error as { message?: string })?.message || 'JSON 解析失败'}`,
+          path,
+        }
+      }
+      const merged = mergeModelsConfigWithRetained(next, retainedRoot)
+      const { config: normalized, warnings } = normalizeModelsConfig(merged)
+      if (warnings.length) {
+        console.warn('[models.json] structure warnings:', warnings.join('; '))
+      }
+      const output = asRecord(merged) ?? normalized
+      await mkdir(dirname(path), { recursive: true })
+      const tmpPath = `${path}.${process.pid}.${Date.now()}.tmp`
+      try {
+        await writeFile(tmpPath, `${JSON.stringify(output, null, 2)}\n`, 'utf-8')
+        await rename(tmpPath, path)
+      } finally {
+        await rm(tmpPath, { force: true }).catch(() => undefined)
+      }
+      return { ok: true as const, path, changed: true }
+    } catch (error: unknown) {
+      return {
+        ok: false as const,
+        error: (error as { message?: string })?.message || '写入失败',
+        path,
+      }
+    }
+  }
+  const result = lightWriteChain.then(run, run)
+  lightWriteChain = result.catch(() => undefined)
+  return result
+}
+
 function resolveApiKeyForFetch(apiKey?: string): string | undefined {
   if (!apiKey) return undefined
   const m = apiKey.match(/^\$([A-Z0-9_]+)$|^\$\{([A-Z0-9_]+)\}$/)
@@ -272,11 +332,22 @@ function modelsListUrl(baseUrl: string): string {
   return `${trimmed}/v1/models`
 }
 
-export async function fetchRemoteModelIds(input: {
-  baseUrl: string
-  apiKey?: string
-  authHeader?: boolean
-}): Promise<{ ok: true; ids: string[] } | { ok: false; error: string }> {
+export type RemoteModelEntry = {
+  id: string
+  name?: string
+  /** OpenAI 兼容响应中的 model_type / type（网关可能有，如 chat / image / video）。 */
+  modelType?: string
+}
+
+/** 从 OpenAI 兼容 /v1/models 拉取完整模型目录（保留类型信息）。 */
+export async function fetchRemoteModels(
+  input: {
+    baseUrl: string
+    apiKey?: string
+    authHeader?: boolean
+  },
+  options?: { timeoutMs?: number },
+): Promise<{ ok: true; models: RemoteModelEntry[] } | { ok: false; error: string }> {
   const baseUrl = input.baseUrl?.trim()
   if (!baseUrl) return { ok: false, error: '缺少 baseUrl' }
   const key = resolveApiKeyForFetch(input.apiKey)
@@ -287,18 +358,65 @@ export async function fetchRemoteModelIds(input: {
     else headers['x-api-key'] = key
   }
   try {
-    const res = await fetch(url, { headers, signal: AbortSignal.timeout(25_000) })
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(options?.timeoutMs ?? 25_000) })
     if (!res.ok) {
       const body = await res.text().catch(() => '')
       return { ok: false, error: `HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ''}` }
     }
-    const data = (await res.json()) as { data?: { id?: string }[]; models?: { id?: string; name?: string }[] }
-    const fromData = (data.data || []).map((m) => m.id).filter(Boolean) as string[]
-    const fromModels = (data.models || []).map((m) => m.id || m.name).filter(Boolean) as string[]
-    const ids = [...new Set([...fromData, ...fromModels])].sort((a, b) => a.localeCompare(b))
-    if (ids.length === 0) return { ok: false, error: '响应中未找到模型列表（需 OpenAI 兼容 /v1/models）' }
-    return { ok: true, ids }
+    const raw = (await res.json()) as {
+      data?: { id?: string; name?: string; model_type?: string; type?: string }[]
+      models?: { id?: string; name?: string; model_type?: string; type?: string }[]
+    }
+    const collect = (rows: typeof raw.data | undefined): RemoteModelEntry[] =>
+      (rows || []).flatMap((m) => {
+        const id = m.id || m.name
+        if (!id) return []
+        return [{ id, name: m.name || id, modelType: m.model_type || m.type }]
+      })
+    const models = [...new Map([...collect(raw.data), ...collect(raw.models)].map((m) => [m.id, m])).values()].sort(
+      (a, b) => a.id.localeCompare(b.id),
+    )
+    if (models.length === 0) return { ok: false, error: '响应中未找到模型列表（需 OpenAI 兼容 /v1/models）' }
+    return { ok: true, models }
   } catch (e: unknown) {
     return { ok: false, error: (e as { message?: string })?.message || '请求失败' }
   }
+}
+
+export async function fetchRemoteModelIds(input: {
+  baseUrl: string
+  apiKey?: string
+  authHeader?: boolean
+}): Promise<{ ok: true; ids: string[] } | { ok: false; error: string }> {
+  const result = await fetchRemoteModels(input)
+  if (!result.ok) return result
+  return { ok: true, ids: result.models.map((m) => m.id) }
+}
+
+const remoteCatalogCache = new Map<string, { at: number; models: RemoteModelEntry[] }>()
+/** 远程模型目录缓存有效期（60 秒）：模型选择器每次打开都会合并远程目录，
+ *  缓存过期时自动拉取最新列表，避免网关上新模型后长时间显示不全。 */
+export const REMOTE_MODEL_CATALOG_TTL_MS = 60_000
+
+/** 带 TTL 缓存的远程模型目录拉取，按 baseUrl 缓存。 */
+export async function fetchRemoteModelsCached(
+  input: {
+    baseUrl: string
+    apiKey?: string
+    authHeader?: boolean
+  },
+  options?: { timeoutMs?: number },
+): Promise<{ ok: true; models: RemoteModelEntry[] } | { ok: false; error: string }> {
+  const baseUrl = input.baseUrl?.trim()
+  if (!baseUrl) return { ok: false, error: '缺少 baseUrl' }
+  const hit = remoteCatalogCache.get(baseUrl)
+  if (hit && Date.now() - hit.at < REMOTE_MODEL_CATALOG_TTL_MS) return { ok: true, models: hit.models }
+  const result = await fetchRemoteModels({ baseUrl, apiKey: input.apiKey, authHeader: input.authHeader }, options)
+  if (result.ok) remoteCatalogCache.set(baseUrl, { at: Date.now(), models: result.models })
+  return result
+}
+
+/** 清空远程模型目录缓存（测试用）。 */
+export function clearRemoteModelCatalogCache(): void {
+  remoteCatalogCache.clear()
 }

--- a/src/main/pi-models-json.ts
+++ b/src/main/pi-models-json.ts
@@ -266,7 +266,7 @@ let lightWriteChain: Promise<unknown> = Promise.resolve()
  */
 export function updateModelsConfigLight(
   apply: (current: PiModelsConfig) => PiModelsConfig,
-  agentDir = join(homedir(), '.pi', 'agent'),
+  agentDir?: string,
 ): Promise<
   | { ok: true; path: string; changed: boolean }
   | { ok: false; error: string; path: string }

--- a/src/main/worker-manager.ts
+++ b/src/main/worker-manager.ts
@@ -747,9 +747,11 @@ export class WorkerManager {
     const r = await this.request('getModels')
     return (r.models as WorkerModelRow[]) || []
   }
-  async reloadModels(): Promise<void> {
+  async reloadModels(sessionFile?: string): Promise<void> {
     if (!this.isRunning) return
-    await this.request('reloadModels')
+    // sessionFile 存在时路由到对应 worker slot：无参只刷新 foreground，
+    // 自动注册模型后若目标会话是后台 slot，旧 worker 仍会报 MODEL_NOT_FOUND
+    await this.request('reloadModels', sessionFile ? { sessionFile } : undefined)
   }
   async getPiSettings(): Promise<Record<string, unknown>> {
     return ((await this.request('getPiSettings')).settings as Record<string, unknown>) || {}

--- a/src/worker/handlers/worker-handlers-catalog.test.ts
+++ b/src/worker/handlers/worker-handlers-catalog.test.ts
@@ -47,7 +47,7 @@ describe('worker model catalog handlers', () => {
     await handleReloadmodels({}, reloadReply)
     await handleGetmodels({}, listReply)
 
-    expect(runtime.refresh).toHaveBeenCalledOnce()
+    expect(runtime.refresh).toHaveBeenCalledWith()
     expect(runtime.getAvailable).toHaveBeenCalledOnce()
     expect(reloadReply).toHaveBeenCalledWith({ type: 'reloadModels-done', ok: true })
     expect(listReply).toHaveBeenCalledWith({

--- a/src/worker/handlers/worker-handlers-catalog.ts
+++ b/src/worker/handlers/worker-handlers-catalog.ts
@@ -11,6 +11,8 @@ export async function handleReloadmodels(msg: WorkerIncomingMessage, reply: Work
             reply({ type: 'error', error: 'MODEL_RUNTIME_NOT_READY' })
             return
           }
+          // 重新读取刚写入的 models.json。这里不显式传 allowNetwork：
+          // 与 setModel 关键路径的稳定性相比，宁可保留 SDK 默认刷新行为。
           await st.modelRuntime.refresh()
           reply({ type: 'reloadModels-done', ok: true })
         } catch (e: unknown) {


### PR DESCRIPTION
## 用户场景 / 问题
用 OpenAI 兼容网关（如自建 gateway / 中转）的用户，模型下拉里只有 config 里手写的少数模型；想用网关上的其他模型必须手改配置文件。而且自动补进 config 的模型默认不开 reasoning，推理模型用起来没有思考过程。

## 修复方案（2 个提交）
1. 从网关 `/v1/models` 拉取模型目录，在模型选择器中展示可选模型；选中未声明的模型时通过 `ensureModelDeclaredInConfig` 自动写入 config（带测试）。
2. 自动注册的 chat 模型默认 `reasoning: true`（现在的推理模型即使标 chat 也普遍支持，开着无害，不开则丢思考块）。