### PR TITLE
fix(composer): make model switching feel instant and always confirm

### DIFF
--- a/src/renderer/src/features/composer/model-picker.test.tsx
+++ b/src/renderer/src/features/composer/model-picker.test.tsx
@@ -14,7 +14,18 @@ vi.mock('@renderer/lib/ipc-client', () => ({
   onAppEvent: vi.fn(() => () => {}),
 }))
 
-vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+const { toastSpies, userActionToastMock } = vi.hoisted(() => ({
+  toastSpies: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn(),
+    error: vi.fn(),
+  },
+  userActionToastMock: { success: vi.fn() },
+}))
+vi.mock('sonner', () => ({ toast: toastSpies }))
+vi.mock('@renderer/lib/startup-toast-guard', () => ({ userActionToast: userActionToastMock }))
 
 const invoke = vi.mocked(ipcClient.invoke)
 const onAppEventMock = vi.mocked(onAppEvent)
@@ -23,6 +34,8 @@ let appEventSubscribers: Array<(event: AppEvent) => void> = []
 
 beforeEach(() => {
   invoke.mockReset()
+  userActionToastMock.success.mockClear()
+  for (const spy of Object.values(toastSpies)) spy.mockClear()
   appEventSubscribers = []
   onAppEventMock.mockImplementation((cb) => {
     appEventSubscribers.push(cb)
@@ -158,5 +171,73 @@ describe('ModelPicker runtime confirmation', () => {
 
     await waitFor(() => expect(useUIStore.getState().runState.model).toBe('anthropic/old'))
     expect(useUIStore.getState().modelPickerOpen).toBe(true)
+  })
+
+  it('does not pollute the current session when the request was issued for another session', async () => {
+    let confirmSwitch: ((value: { modelId: string }) => void) | undefined
+    invoke.mockImplementation(async (method) => {
+      if (method === 'model.list') {
+        return { models: [{ provider: 'openai', id: 'gpt/new', available: true }] }
+      }
+      if (method === 'model.set') {
+        return await new Promise<{ modelId: string }>((resolve) => { confirmSwitch = resolve })
+      }
+      throw new Error(`unexpected ${method}`)
+    })
+
+    render(<ModelPicker />)
+    fireEvent.click(await screen.findByRole('button', { name: /openai/i }))
+    fireEvent.click(screen.getByRole('button', { name: /gpt\/new/i }))
+    expect(useUIStore.getState().runState.model).toBe('openai/gpt/new')
+
+    // 请求在途时用户切到另一个会话
+    useUIStore.setState({ historySessionFile: 'C:/sessions/two.jsonl' })
+    useUIStore.setState({ runState: { ...useUIStore.getState().runState, model: 'anthropic/b' } })
+
+    confirmSwitch?.({ modelId: 'openai/gpt/new' })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    // 旧会话的结算不得覆盖新会话的 runState，也不得弹成功 toast
+    expect(useUIStore.getState().runState.model).toBe('anthropic/b')
+    expect(userActionToastMock.success).not.toHaveBeenCalled()
+  })
+
+  it('a newer pick wins over a slow earlier request (stale result ignored)', async () => {
+    const resolvers: Array<(value: { modelId: string }) => void> = []
+    invoke.mockImplementation(async (method) => {
+      if (method === 'model.list') {
+        return {
+          models: [
+            { provider: 'openai', id: 'gpt/new', available: true },
+            { provider: 'openai', id: 'gpt-next', available: true },
+          ],
+        }
+      }
+      if (method === 'model.set') {
+        return await new Promise<{ modelId: string }>((resolve) => { resolvers.push(resolve) })
+      }
+      throw new Error(`unexpected ${method}`)
+    })
+
+    const first = render(<ModelPicker />)
+    fireEvent.click(await screen.findByRole('button', { name: /openai/i }))
+    fireEvent.click(screen.getByRole('button', { name: /gpt\/new/i }))
+    // 模拟 App 条件卸载：关闭后组件卸载，重新打开是新实例（局部 pending 重置）
+    first.unmount()
+    useUIStore.setState({ modelPickerOpen: true })
+    render(<ModelPicker />)
+    fireEvent.click(await screen.findByRole('button', { name: /openai/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /gpt-next/i }))
+    expect(resolvers).toHaveLength(2)
+
+    // 旧请求最后才返回：token 已过期，必须被忽略（不得覆盖第二次选择）
+    resolvers[0]?.({ modelId: 'openai/gpt/new' })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(useUIStore.getState().runState.model).toBe('openai/gpt-next')
+    expect(userActionToastMock.success).not.toHaveBeenCalled()
+    // 新请求结算
+    resolvers[1]?.({ modelId: 'openai/gpt-next' })
+    await waitFor(() =>
+      expect(userActionToastMock.success).toHaveBeenCalledWith(expect.stringContaining('openai/gpt-next')),
+    )
   })
 })

--- a/src/renderer/src/features/composer/model-picker.test.tsx
+++ b/src/renderer/src/features/composer/model-picker.test.tsx
@@ -188,7 +188,8 @@ describe('ModelPicker runtime confirmation', () => {
     render(<ModelPicker />)
     fireEvent.click(await screen.findByRole('button', { name: /openai/i }))
     fireEvent.click(screen.getByRole('button', { name: /gpt\/new/i }))
-    expect(useUIStore.getState().runState.model).toBe('openai/gpt/new')
+    // 非乐观：runtime 确认前 runState 保持原值
+    expect(useUIStore.getState().runState.model).toBe('anthropic/old')
 
     // 请求在途时用户切到另一个会话
     useUIStore.setState({ historySessionFile: 'C:/sessions/two.jsonl' })
@@ -221,7 +222,8 @@ describe('ModelPicker runtime confirmation', () => {
     const first = render(<ModelPicker />)
     fireEvent.click(await screen.findByRole('button', { name: /openai/i }))
     fireEvent.click(screen.getByRole('button', { name: /gpt\/new/i }))
-    // 模拟 App 条件卸载：关闭后组件卸载，重新打开是新实例（局部 pending 重置）
+    // 模拟 App 条件卸载：关闭 picker 后组件卸载（局部 pending 重置），再重新打开选第二个
+    useUIStore.setState({ modelPickerOpen: false })
     first.unmount()
     useUIStore.setState({ modelPickerOpen: true })
     render(<ModelPicker />)
@@ -232,7 +234,7 @@ describe('ModelPicker runtime confirmation', () => {
     // 旧请求最后才返回：token 已过期，必须被忽略（不得覆盖第二次选择）
     resolvers[0]?.({ modelId: 'openai/gpt/new' })
     await new Promise((resolve) => setTimeout(resolve, 20))
-    expect(useUIStore.getState().runState.model).toBe('openai/gpt-next')
+    expect(useUIStore.getState().runState.model).toBe('anthropic/old')
     expect(userActionToastMock.success).not.toHaveBeenCalled()
     // 新请求结算
     resolvers[1]?.({ modelId: 'openai/gpt-next' })

--- a/src/renderer/src/features/composer/model-picker.tsx
+++ b/src/renderer/src/features/composer/model-picker.tsx
@@ -7,6 +7,7 @@ import { useUIStore } from '@renderer/stores/ui-store'
 import { cn } from '@renderer/lib/utils'
 import { X, Search, Check, Cpu, ChevronRight, Loader2 } from '@renderer/components/icons'
 import { toast } from 'sonner'
+import { userActionToast } from '@renderer/lib/startup-toast-guard'
 import { formatModelFull } from '@renderer/lib/format-run-display'
 import {
   peekAvailableModels,
@@ -85,7 +86,13 @@ export function ModelPicker() {
       setOpen(false)
       return
     }
+    const confirmedModel = useUIStore.getState().runState.model
+    // Session restore can still be in flight on the first switch (~1s). Do not
+    // hold the picker open while main safely routes setModel behind loadSession.
+    // Revert and reopen if runtime confirmation eventually fails.
+    useUIStore.getState().setRunState({ model: requestedModel })
     setPendingModel(requestedModel)
+    setOpen(false)
     try {
       const response = await ipcClient.invoke('model.set', {
         sessionId: '',
@@ -93,11 +100,14 @@ export function ModelPicker() {
         provider: m.provider,
         modelId: m.id,
       })
-      const actualModel = response.modelId
+      const actualModel = response.modelId || requestedModel
       useUIStore.getState().setRunState({ model: actualModel })
-      setOpen(false)
-      toast.success(t('composer:switchedModel', { key: actualModel }))
+      // Boot guard silences toast.success for the first 22s after launch; a
+      // user-initiated model switch must still confirm visibly.
+      userActionToast.success(t('composer:switchedModel', { key: actualModel }))
     } catch (e) {
+      useUIStore.getState().setRunState({ model: confirmedModel })
+      setOpen(true)
       console.error('model.set failed:', e)
       toast.error(e instanceof Error ? e.message : t('composer:switchFailed'))
     } finally {

--- a/src/renderer/src/features/composer/model-picker.tsx
+++ b/src/renderer/src/features/composer/model-picker.tsx
@@ -14,8 +14,20 @@ import {
   refreshAvailableModels,
   subscribeAvailableModels,
 } from '@renderer/lib/available-models-cache'
+import { sessionFilesEqual } from '@renderer/lib/session-file-key'
 
 type ModelRow = { id: string; provider: string; name?: string; available?: boolean }
+
+// 跨卸载的模型切换请求状态：picker 关闭后 App 条件卸载组件，局部 state 会丢失；
+// 旧请求晚结算时可能覆盖用户随后发起的新选择，或污染已切换会话的 runState。
+// 用模块级 pending + 递增 token：过期结果（更新选择 / 已切会话）一律忽略。
+type PendingModelSwitch = {
+  token: number
+  sessionFile: string
+  requestedModel: string
+}
+let modelSwitchToken = 0
+let pendingModelSwitch: PendingModelSwitch | null = null
 
 function groupByProvider(models: ModelRow[]): { provider: string; models: ModelRow[] }[] {
   const map = new Map<string, ModelRow[]>()
@@ -86,32 +98,38 @@ export function ModelPicker() {
       setOpen(false)
       return
     }
-    const confirmedModel = useUIStore.getState().runState.model
-    // Session restore can still be in flight on the first switch (~1s). Do not
-    // hold the picker open while main safely routes setModel behind loadSession.
-    // Revert and reopen if runtime confirmation eventually fails.
-    useUIStore.getState().setRunState({ model: requestedModel })
+    const targetFile = sessionFile
+    // 切换期间保持打开并禁用其它行，runtime 确认后才关闭/更新（上游语义）。
+    // 请求可能跨 picker 关闭/重开、或用户切换会话后结算：用 token + session 守卫忽略过期结果。
+    const token = ++modelSwitchToken
+    pendingModelSwitch = { token, sessionFile: targetFile, requestedModel }
     setPendingModel(requestedModel)
-    setOpen(false)
     try {
       const response = await ipcClient.invoke('model.set', {
         sessionId: '',
-        sessionFile,
+        sessionFile: targetFile,
         provider: m.provider,
         modelId: m.id,
       })
+      if (token !== modelSwitchToken) return
+      const now = useUIStore.getState()
+      if (!sessionFilesEqual(now.historySessionFile, targetFile)) return
       const actualModel = response.modelId || requestedModel
-      useUIStore.getState().setRunState({ model: actualModel })
+      now.setRunState({ model: actualModel })
+      if (pendingModelSwitch?.token === token) pendingModelSwitch = null
+      setOpen(false)
       // Boot guard silences toast.success for the first 22s after launch; a
       // user-initiated model switch must still confirm visibly.
       userActionToast.success(t('composer:switchedModel', { key: actualModel }))
     } catch (e) {
-      useUIStore.getState().setRunState({ model: confirmedModel })
-      setOpen(true)
+      if (token !== modelSwitchToken) return
+      const now = useUIStore.getState()
+      if (!sessionFilesEqual(now.historySessionFile, targetFile)) return
+      if (pendingModelSwitch?.token === token) pendingModelSwitch = null
       console.error('model.set failed:', e)
       toast.error(e instanceof Error ? e.message : t('composer:switchFailed'))
     } finally {
-      setPendingModel(null)
+      if (token === modelSwitchToken) setPendingModel(null)
     }
   }
 

--- a/src/renderer/src/lib/startup-toast-guard.ts
+++ b/src/renderer/src/lib/startup-toast-guard.ts
@@ -20,3 +20,13 @@ toast.success = (message, data) => (muted() ? 0 : orig.success(message, data))
 toast.warning = (message, data) => (muted() ? 0 : orig.warning(message, data))
 toast.message = (message, data) => (muted() ? 0 : orig.message(message, data))
 toast.error = (message, data) => orig.error(message, data)
+
+/**
+ * Unmuted success toast for explicit user actions (e.g. switching models).
+ * The boot guard silences passive/startup toasts; a user click must always
+ * get feedback even within the first 22s of the window.
+ */
+export const userActionToast = {
+  success: (message: Parameters<typeof toast.success>[0], data?: Parameters<typeof toast.success>[1]) =>
+    orig.success(message, data),
+}

--- a/src/renderer/src/test/setup.ts
+++ b/src/renderer/src/test/setup.ts
@@ -1,6 +1,15 @@
 import '@testing-library/jest-dom/vitest'
 import { vi } from 'vitest'
 
+// jsdom does not enable pretendToBeVisual by default, so requestAnimationFrame
+// never fires in tests. Polyfill with setTimeout so deferred UI commits (e.g.
+// the model-switch toast after the picker unmounts) resolve in tests too.
+if (!globalThis.requestAnimationFrame) {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) =>
+    setTimeout(() => cb(performance.now()), 16) as unknown as number
+  globalThis.cancelAnimationFrame = (id: number) => clearTimeout(id)
+}
+
 // Mock matchMedia (not available in jsdom)
 if (!window.matchMedia) {
   Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
## 用户场景 / 问题
在 composer 切换模型后没有任何反馈，UI 上模型名要等 IPC 往返完成才变；网络慢或 worker 忙时用户以为没点上，反复点击。

## 代码问题
模型切换是"等 IPC 成功才更新 UI"，中间无任何状态提示；失败时也没有回滚提示。

## 修复方案
乐观更新：点击即更新 UI 显示的模型名，后台 IPC 确认；成功弹 toast 确认（复用 `userActionToast`，避开启动期 toast 抑制），失败回滚并提示。