### PR TITLE
feat(session): auto-generate session titles from the first user message

### DIFF
--- a/doc/CONTEXT.md
+++ b/doc/CONTEXT.md
@@ -5,6 +5,54 @@
 侧栏项目列表默认按最近使用（MRU）排序：打开项目时 `configStore.addRecentProject` 把项目移到最前，且当前工作区始终置顶（`project-sidebar.tsx` 的 `diskPaths`）。新增配置项 `recentProjectsFixedOrder`（默认 `false`，保持 MRU 行为）：开启后 `nextRecentProjects` 不再移动已有项目（新项目追加到末尾），侧栏按存储顺序展示且当前项目不置顶（仅高亮）。纯函数：`src/main/recent-projects.ts`、`src/renderer/src/features/workspace/project-folder-order.ts`。设置页「最近项目」区开关直接写配置并派发 `pi-desktop:settings-changed` 事件通知侧栏即时重排。
 
 **闪烁根因（勿回退）**：`ui-store.setWorkspace` 曾把当前工作区 unshift 到 `recentProjects` 最前——固定模式下侧栏先跳顶，随后 `reloadSidebarSettings` 从主进程拉回真实顺序——先跳再弹回 = 每次切换可见闪烁。修复：`setWorkspace` 不再重排 `recentProjects`（侧栏顺序以主进程配置为唯一事实源；MRU 模式由 `projectFolderOrder` 的“当前置顶”规则兜底即时显示）。另：`reloadSidebarSettings` 在顺序无变化时保持数组引用稳定，避免固定模式下每次切换都触发整个侧栏重渲染。
+## 会话树交互术语（glossary）
+
+- **查看跳转（view-jump）**：单击会话树节点，时间线非破坏性定位到该节点对应的消息。历史未加载时先触发只读补拉，加载完成后再跳转；不改变会话叶子、不回退、不打断用户输入。
+- **回退（rewind）**：双击会话树节点或使用回退按钮，将会话当前位置移动到该节点（改变叶子，可再回退恢复）。
+- **全局统一**：右栏会话树面板与双击 Esc 的会话树浮层交互一致：单击或 Enter=查看跳转，双击=回退。
+
+### 决策记录：单击=查看、双击=回退（2026）
+
+会话树曾两次被改错：`a34ffa2` 把单击改成仅选中（“点击没反应”），后续提交又把单击改成直接回退（破坏性）。正确语义：**单击/Enter=非破坏性查看跳转**（时间线定位到该节点，不改叶子、不打扰输入；未加载的历史只读补拉并增量合并，时间线始终代表真实最新）；**双击=回退**（navigateTree）。勿再改为“单击=回退”。
+## 外部会话同步术语（glossary）
+
+- **外部更新（external update）**：非本 app worker 对会话 JSONL 的追加（典型：CLI 并发写同一会话）。app 空闲时**自动**把磁盘新尾部合并进时间线视图（不改变 worker 内存态）；同步状态由 composer 上方**三态指示器**呈现（见下）；完整手动刷新走右上角「刷新会话数据」按钮。
+
+### 决策记录：外部更新走视图层只读合并，不重载 worker（2026）
+
+CLI 与 app 同开一会话时，CLI 追加 JSONL。检测到外部更新后，app 只把磁盘新尾部合并进时间线视图（读路径 `session.getMessages` 本就磁盘直读、不依赖 worker），**绝不自动重载/覆盖 worker 内存态**——避免并发写互相覆盖与上下文丢失。监测机制：fs.watch 当前工作区会话目录（一个 watcher）+ 事件路由（命中当前会话→尾合并；新文件→刷新列表），切换会话只改路由；**定时轮询（~3s）兜底 Windows 丢事件**，另 debounce + 窗口聚焦时强制刷新。
+
+### 决策记录：外部同步用三态指示器，不做发送前确认弹窗（2026）
+
+实时同步已把磁盘尾部并入视图，弹窗冗余且打断输入。composer 上方**三态指示器**（`externalSyncPhase` 驱动）：外部写入合并成功 → **绿色脉冲「正在同步外部对话」**，约 5s 无外部写入自动隐藏（本轮结束）；IPC 同步异常 → **橙/红「外部同步异常」**，点击触发完整重载；空闲不渲染。**实现注意**：zustand `setState` 返回 `undefined`，判断"是否有新增"必须在 updater 内用局部变量捕获，不能靠返回值。
+
+### TODO：实时思考过程同步（等待 pi 支持流式落盘）
+
+pi CLI 的会话 JSONL 是**消息级落盘**（磁盘无流式中间条目，thinking+text+toolCall 同一条消息一次性 append）。因此 app 同步 CLI 会话的粒度上限 = 每条消息完成，CLI 思考过程中 app 看不到中间状态。**等 pi 支持思考块逐块落盘后**再回来做实时思考同步。勿再优化 watcher debounce/轮询间隔（那是消息级延迟，不是思考级）。
+## 会话显示特性术语（glossary）
+
+- **过程内容（activity item）**：时间线里非对话正文的条目——思考块（thinking）、工具调用行（tool-call，含命令执行）、skill 调用块。与对话正文（user/assistant 气泡）相对。
+- **活动窗口（activity window）**：过程内容的滚动展开窗口，大小 N 可在设置中配置。默认折叠所有过程内容，仅**自动展开最新 N 个**；有新增过程内容时，超出窗口的最旧项回到折叠态。**用户手动展开/折叠优先于窗口**（窗口不强制折叠用户明确展开的项）。N=0 表示禁用窗口（保持纯手动行为）。整个时间线统一计数，不按回合分界。
+- **元事件条目（non-message entry）**：`model_change` / `thinking_level_change` 等非消息 JSONL 条目。默认不展示；设置开关打开后，在时间线中以一行小字展示（如「切换到 acme/example-model · thinking: high」），相邻的 model+thinking 变更合并为一条。
+- **skill 调用块（skill invocation）**：以 `<skill name="..." location="...">` 开头的独立用户消息（pi 把 skill 内容作为用户消息注入）。渲染为一行折叠摘要「调用 skill: <name>」，点击展开全文；**默认折叠、不受活动窗口 N 限制**；摘要层不显示 location 路径（含本机用户名，避免泄漏）。
+
+### 决策记录：活动窗口与 skill/元事件展示（2026）
+
+时间线可读性与信息容积的权衡：过程内容全展开则 AI 执行时刷屏，全折叠则看不到进展。定案：**默认折叠 + 滑动窗口自动展开最新 N 个 + 手动优先**（见 glossary「活动窗口」）；skill 调用块单独折叠（默认折叠、不受窗口限制）；元事件条目默认隐藏、开关可开。这三类均为纯展示层行为，**开关与 N 存放 app 私有 config-store，不进 pi settings**。
+## 会话归档术语（glossary）
+
+- **归档（archived）**：把会话从默认列表隐藏；元数据存 configStore（`Record<规范化会话文件路径, 归档时间戳>`），侧栏"已归档"视图可恢复/删除。归档会话收到新消息**不会**自动取消归档。
+
+### 决策记录：归档状态只用元数据，不移动文件（2026）
+
+会话文件路径是 TUI 与 app 共享的稳定定位键，移动/重命名会破坏 worker 绑定与树引用。因此**归档 = configStore `Record<路径, 时间戳>`**，文件原地不动。
+## 会话管理特性术语（glossary）
+
+- **自动命名（auto-name）**：手动触发（重命名对话框内"自动生成"），用规则从会话首条用户消息提取标题（剥离行首 `/` 命令调用、剔除 URL 与文件路径——不适宜作标题、折叠空白、截断约 40~50 字），结果经 `session_info` 写入 JSONL（与 TUI `/name` 同机制），**不重命名会话文件或文件夹**。已有人工命名（存在 `session_info`）的会话点自动命名时覆盖。
+
+### 决策记录：会话标题只用元数据，不重命名文件（2026）
+
+会话文件路径（`~/.pi/agent/sessions/<编码cwd>/<时间戳>_<uuid>.jsonl`）是 TUI 与 app 共享的稳定定位键，重命名会破坏 `sessionDisplayNames` 键、worker 绑定、树引用等。因此：**标题 = JSONL `session_info`（TUI 可见）+ configStore overlay（app 本地）**。勿再考虑重命名会话文件/文件夹。
 
 ## 进程边界
 

--- a/packages/shared/ipc-channels.ts
+++ b/packages/shared/ipc-channels.ts
@@ -86,6 +86,8 @@ export const IPC_INVOKE_CHANNELS = [
   'ipc:session.prepare',
   'ipc:session.reloadFromDisk',
   'ipc:session.rename',
+  'ipc:session.autoNamePreview',
+
   'ipc:session.setEphemeralDraft',
   'ipc:session.setPendingBind',
   'ipc:session.tree',

--- a/packages/shared/ipc-contract.ts
+++ b/packages/shared/ipc-contract.ts
@@ -40,6 +40,8 @@ export interface SessionInfo {
   status: 'idle' | 'busy' | 'error'
 }
 export interface SessionListRequest { workspaceId?: string }
+export interface SessionAutoNamePreviewRequest { sessionFile: string }
+export interface SessionAutoNamePreviewResponse { ok: boolean; title?: string; error?: string }
 export interface SessionListResponse { sessions: SessionInfo[] }
 export interface SessionOpenRequest { sessionId: string; sessionFile?: string }
 export interface SessionOpenResponse { session: SessionInfo }
@@ -300,6 +302,7 @@ export interface IpcMethodMap {
   'session.forkCandidates': { request: SessionForkCandidatesRequest; response: SessionForkCandidatesResponse }
   'session.clone': { request: SessionCloneRequest; response: SessionCloneResponse }
   'session.rename': { request: SessionRenameRequest; response: SessionRenameResponse }
+  'session.autoNamePreview': { request: SessionAutoNamePreviewRequest; response: SessionAutoNamePreviewResponse }
   'session.compact': { request: SessionCompactRequest; response: SessionCompactResponse }
   'session.export': { request: SessionExportRequest; response: SessionExportResponse }
   'context.preview': { request: ContextPreviewRequest; response: ContextPreviewResponse }

--- a/src/main/__tests__/session-auto-name.test.ts
+++ b/src/main/__tests__/session-auto-name.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { autoNameTitle, cleanAutoNameText } from '../session-auto-name'
+
+describe('cleanAutoNameText', () => {
+  it('strips leading /command lines and keeps the intent', () => {
+    expect(cleanAutoNameText('/batch-grill-with-docs\n/sanitize-commit\n我希望增加几个功能特性：\n你好')).toBe(
+      '我希望增加几个功能特性： 你好',
+    )
+  })
+
+  it('keeps inline slashes like "/ shift + enter" mid-text', () => {
+    expect(cleanAutoNameText('修复问题：\n我在输出窗输入 换行时，/ shift + enter\n超出阈值')).toBe(
+      '修复问题： 我在输出窗输入 换行时，/ shift + enter 超出阈值',
+    )
+  })
+
+  it('removes URLs (not title material)', () => {
+    expect(cleanAutoNameText('/sanitize-commit\n\nhttps://example.com/org/repo/pull/57 新增了3个提交')).toBe(
+      '新增了3个提交',
+    )
+  })
+
+  it('drops a line that is only a URL', () => {
+    expect(cleanAutoNameText('https://example.com/org/repo/pull/57')).toBe('')
+  })
+
+  it('removes Windows drive paths (backslash and forward slash)', () => {
+    expect(cleanAutoNameText('修改 C:\\Users\\dev\\config.json 的配置')).toBe('修改 的配置')
+    expect(cleanAutoNameText('在 D:/Github/pi-app 提交代码')).toBe('在 提交代码')
+  })
+
+  it('removes Unix absolute/home/relative paths', () => {
+    expect(cleanAutoNameText('看下 /tmp/build.log 和 ~/.pi/agent 目录')).toBe('看下 和 目录')
+    expect(cleanAutoNameText('运行 ./scripts/build.sh 试试')).toBe('运行 试试')
+  })
+
+  it('keeps a mid-line slash phrase like "/ shift + enter" intact', () => {
+    expect(cleanAutoNameText('修复问题：\n我在输出窗输入 换行时，/ shift + enter\n超出阈值')).toBe(
+      '修复问题： 我在输出窗输入 换行时，/ shift + enter 超出阈值',
+    )
+  })
+
+  it('collapses whitespace and trims', () => {
+    expect(cleanAutoNameText('  首条消息\n\n\n第二行\t\t空白  ')).toBe('首条消息 第二行 空白')
+  })
+})
+
+describe('autoNameTitle', () => {
+  it('extracts first user message, truncates to 40 chars', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pi-auto-name-'))
+    try {
+      const file = join(dir, '2026-01-01T00-00-00-000Z_019f0000-0000-7000-8000-000000000000.jsonl')
+      writeFileSync(
+        file,
+        [
+          JSON.stringify({ type: 'session', id: '019f0000-0000-7000-8000-000000000000', cwd: dir }),
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'system',
+              content: [{ type: 'text', text: 'system context' }],
+            },
+          }),
+          JSON.stringify({
+            type: 'message',
+            message: {
+              role: 'user',
+              content: [
+                {
+                  type: 'text',
+                  text: '/grill\n请帮我评估这个方案的可行性，它涉及很多模块的改动，需要仔细分析每一个边界情况，并且还要对比不同的实现路径和它们各自的维护成本，最后给出建议',
+                },
+              ],
+            },
+          }),
+          '',
+        ].join('\n'),
+      )
+      const title = await autoNameTitle(file)
+      expect(title.startsWith('请帮我评估这个方案的可行性')).toBe(true)
+      expect([...title].length).toBeLessThanOrEqual(41)
+      expect(title.endsWith('…')).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to sessionId head when no user message', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pi-auto-name-'))
+    try {
+      const file = join(dir, '2026-01-01T00-00-00-000Z_019f0000-0000-7000-8000-000000000000.jsonl')
+      writeFileSync(file, [JSON.stringify({ type: 'session', id: '019f0000-0000-7000-8000-000000000000' })].join('\n'))
+      expect(await autoNameTitle(file)).toBe('019f0000')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to sessionId head when first message is only a URL/path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pi-auto-name-'))
+    try {
+      const file = join(dir, '2026-01-01T00-00-00-000Z_019f0000-0000-7000-8000-000000000000.jsonl')
+      writeFileSync(
+        file,
+        [
+          JSON.stringify({ type: 'session', id: '019f0000-0000-7000-8000-000000000000' }),
+          JSON.stringify({
+            type: 'message',
+            message: { role: 'user', content: '/sanitize-commit\n\nhttps://example.com/org/repo/pull/57' },
+          }),
+        ].join('\n'),
+      )
+      expect(await autoNameTitle(file)).toBe('019f0000')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('skips partial/invalid JSONL lines mid-scan', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pi-auto-name-'))
+    try {
+      const file = join(dir, '2026-01-01T00-00-00-000Z_019f0000-0000-7000-8000-000000000000.jsonl')
+      writeFileSync(
+        file,
+        [
+          JSON.stringify({ type: 'session', id: '019f0000-0000-7000-8000-000000000000' }),
+          '{"type":"message","message":{"role":"user","content":"半行', // CLI 写入中
+          JSON.stringify({ type: 'message', message: { role: 'user', content: '完整消息' } }),
+        ].join('\n'),
+      )
+      expect(await autoNameTitle(file)).toBe('完整消息')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/ipc/handlers/session.ts
+++ b/src/main/ipc/handlers/session.ts
@@ -5,6 +5,7 @@ import { listMessageAnchorsFromSessionFile } from '../../session-branch-anchors'
 import { readSessionIdFromFile } from '../../session-file-meta'
 import { resolvePreparedSessionFile } from '../../session-prepare'
 import { clearSessionDisplayName, resolveSessionListTitle } from '../../session-display-names'
+import { autoNameTitle } from '../../session-auto-name'
 import { renamePiSessionOnDisk } from '../../rename-pi-session'
 import {
   bindSandboxSession,
@@ -535,6 +536,18 @@ export function registerSessionHandlers(): void {
     clearSessionDisplayName(file)
     await sessionPreviewProcess.invalidateListSessions(workspaceCwd)
     return { ok: true, title }
+  })
+
+  registerHandler('ipc:session.autoNamePreview', async (req) => {
+    const file = (req.sessionFile as string | undefined)?.trim()
+    if (!file) return { ok: false, error: 'missing sessionFile' }
+    try {
+      const title = await autoNameTitle(file)
+      if (!title) return { ok: false, error: 'no title source' }
+      return { ok: true, title }
+    } catch (e: unknown) {
+      return { ok: false, error: errorMessage(e) || 'autoName failed' }
+    }
   })
 
   registerHandlerWithSchema('ipc:session.delete', sessionDeleteSchema, async (req) => {

--- a/src/main/session-auto-name.ts
+++ b/src/main/session-auto-name.ts
@@ -1,0 +1,101 @@
+import { createReadStream } from 'fs'
+import { createInterface } from 'readline'
+import { readSessionIdFromFile } from './session-file-meta'
+
+/**
+ * 自动命名：从会话首条用户消息用规则提取标题（不调用模型）。
+ * 规则：剥离行首 `/` 命令调用行 → 剔除 URL 与文件路径（不适宜作标题）→ 折叠空白 → 按字符截断 40 字。
+ * 结果写入 JSONL `session_info` 由调用方（rename 通道）负责。
+ */
+
+const MAX_LINES = 4000
+const MAX_TITLE_CHARS = 40
+
+const URL_RE = /https?:\/\/[^\s]*/gi
+// 文件路径：Windows 盘符路径（C:\…、C:/…）、Unix 绝对/家目录/相对路径（/x、~/x、./x、../x）。
+// `\/[^\s]+` 要求斜杠后紧跟非空白字符，避免误伤行中的 “/ shift” 这类普通斜杠。
+const FILE_PATH_RE = /(?:[A-Za-z]:[\\/]|(?:\/|~\/|\.{1,2}[\\/]))[^\s]+/gi
+
+type SessionEntry = {
+  type?: string
+  message?: { role?: string; content?: unknown }
+}
+
+function messageTextContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (p): p is { type?: string; text?: unknown } =>
+          !!p && typeof p === 'object' && (p as { type?: string }).type === 'text',
+      )
+      .map((p) => String(p.text ?? ''))
+      .join('')
+  }
+  return ''
+}
+
+/** 有界扫描 JSONL 头部，取首条 user 消息文本（避免整文件加载）。 */
+export async function readFirstUserMessageText(sessionFile: string): Promise<string> {
+  const rl = createInterface({
+    input: createReadStream(sessionFile, { encoding: 'utf8' }),
+    crlfDelay: Infinity,
+  })
+  let lines = 0
+  try {
+    for await (const line of rl) {
+      if (++lines > MAX_LINES) break
+      if (!line.trim()) continue
+      let entry: SessionEntry
+      try {
+        entry = JSON.parse(line) as SessionEntry
+      } catch {
+        continue // 半行（CLI 写入中）跳过
+      }
+      if (entry.type !== 'message') continue
+      const msg = entry.message
+      if (!msg || msg.role !== 'user') continue
+      const text = messageTextContent(msg.content).trim()
+      if (text) return text
+    }
+  } finally {
+    rl.close()
+  }
+  return ''
+}
+
+/**
+ * 清洗规则：
+ * - 剥离「行首以 / 开头」的命令调用行（含前导空行），直到出现非命令文本；行中斜杠不动
+ * - 剔除 URL（http/https）与文件路径（Windows 盘符、Unix 绝对/家目录/相对路径）——不适宜作标题
+ * - 剔除后为空的整行丢弃；折叠换行/连续空白为单空格
+ */
+export function cleanAutoNameText(raw: string): string {
+  const lines = raw.split(/\r?\n/)
+  const meaningful: string[] = []
+  let sawContent = false
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!sawContent) {
+      if (!trimmed) continue // 前导空行
+      if (/^\/\S/.test(trimmed)) continue // 行首 / 命令（/x 形式，非 "/ shift"）
+      sawContent = true
+    }
+    const cleaned = trimmed.replace(URL_RE, ' ').replace(FILE_PATH_RE, ' ').replace(/\s+/g, ' ').trim()
+    if (cleaned) meaningful.push(cleaned)
+  }
+  return meaningful.join(' ').trim()
+}
+
+function truncateChars(s: string, max: number): string {
+  if ([...s].length <= max) return s
+  return [...s].slice(0, max).join('').replace(/[，。、；：,.…\s]+$/, '') + '…'
+}
+
+export async function autoNameTitle(sessionFile: string): Promise<string> {
+  const raw = await readFirstUserMessageText(sessionFile)
+  const cleaned = cleanAutoNameText(raw)
+  if (cleaned) return truncateChars(cleaned, MAX_TITLE_CHARS)
+  const id = readSessionIdFromFile(sessionFile)
+  return id ? id.slice(0, 8) : ''
+}

--- a/src/renderer/src/features/workspace/rename-prompt-dialog.tsx
+++ b/src/renderer/src/features/workspace/rename-prompt-dialog.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
+import { Sparkles } from '@renderer/components/icons'
 
 export function RenamePromptDialog({
   open,
   title,
   defaultValue,
   placeholder,
+  autoNameTarget,
   onConfirm,
   onCancel,
 }: {
@@ -14,6 +16,8 @@ export function RenamePromptDialog({
   title: string
   defaultValue: string
   placeholder?: string
+  /** 传入后显示「自动生成」按钮：调用 session.autoNamePreview 填充标题 */
+  autoNameTarget?: { sessionFile: string } | null
   onConfirm: (value: string) => void | Promise<void>
   onCancel: () => void
 }) {
@@ -22,11 +26,13 @@ export function RenamePromptDialog({
   const inputRef = useRef<HTMLInputElement>(null)
   const [value, setValue] = useState(defaultValue)
   const [busy, setBusy] = useState(false)
+  const [generating, setGenerating] = useState(false)
 
   useEffect(() => {
     if (!open) return
     setValue(defaultValue)
     setBusy(false)
+    setGenerating(false)
     const t = window.setTimeout(() => {
       inputRef.current?.focus()
       inputRef.current?.select()
@@ -54,6 +60,27 @@ export function RenamePromptDialog({
       await onConfirm(trimmed)
     } finally {
       setBusy(false)
+    }
+  }
+
+  const autoGenerate = async () => {
+    if (generating || !autoNameTarget) return
+    setGenerating(true)
+    try {
+      const { ipcClient } = await import('@renderer/lib/ipc-client')
+      const r = await ipcClient.invoke('session.autoNamePreview', {
+        sessionFile: autoNameTarget.sessionFile,
+      })
+      const next = r?.title
+      if (typeof next === 'string' && next.trim()) {
+        setValue(next.trim())
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      }
+    } catch (e) {
+      console.warn('[rename] autoNamePreview failed:', e)
+    } finally {
+      setGenerating(false)
     }
   }
 
@@ -89,6 +116,18 @@ export function RenamePromptDialog({
           }}
         />
         <div className="flex justify-end gap-2">
+          {autoNameTarget && (
+            <button
+              type="button"
+              disabled={generating || busy}
+              className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[13px] text-foreground-secondary hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+              onClick={() => void autoGenerate()}
+              title={t('common:sidebar.autoNameHint')}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              {generating ? t('common:loading') : t('common:sidebar.autoGenerate')}
+            </button>
+          )}
           <button
             type="button"
             disabled={busy}

--- a/src/renderer/src/features/workspace/sandbox-context-menu.test.tsx
+++ b/src/renderer/src/features/workspace/sandbox-context-menu.test.tsx
@@ -1,0 +1,64 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SandboxContextMenuPortal } from './sandbox-context-menu'
+
+const invokeMock = vi.fn(async (_method: unknown, _req?: unknown) => ({}))
+vi.mock('@renderer/lib/ipc-client', () => ({
+  ipcClient: { invoke: (method: unknown, req?: unknown) => invokeMock(method, req) },
+}))
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+vi.mock('@renderer/stores/ui-store', () => ({
+  useUIStore: {
+    getState: () => ({ currentWorkspace: null, setWorkspace: () => {}, clearTimeline: () => {}, setCurrentSession: () => {}, loadHistoryItems: () => {}, setHistoryMeta: () => {} }),
+    setState: () => {},
+  },
+}))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+const MENU = { x: 10, y: 10, path: '/sandbox-workspaces/abc', label: '临时对话 abc', sessionFile: '/sandbox-workspaces/abc/s.jsonl' }
+
+describe('SandboxContextMenuPortal rename auto-name', () => {
+  afterEach(() => {
+    invokeMock.mockClear()
+  })
+
+  it('offers 自动生成 in the rename dialog when a session file is bound', async () => {
+    invokeMock.mockResolvedValue({ ok: true, title: '帮我修 bug' })
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <SandboxContextMenuPortal menu={MENU} onClose={onClose} onListChange={() => {}} />,
+    )
+    await act(async () => {
+      fireEvent.click(screen.getByText('common:sidebar.rename'))
+    })
+    rerender(<SandboxContextMenuPortal menu={null} onClose={onClose} onListChange={() => {}} />)
+
+    const autoButton = screen.getByText('common:sidebar.autoGenerate')
+    expect(autoButton).toBeTruthy()
+    await act(async () => {
+      fireEvent.click(autoButton)
+    })
+    expect(invokeMock).toHaveBeenCalledWith('session.autoNamePreview', {
+      sessionFile: '/sandbox-workspaces/abc/s.jsonl',
+    })
+    expect((document.querySelector('input[type="text"]') as HTMLInputElement).value).toBe('帮我修 bug')
+  })
+
+  it('hides 自动生成 when the sandbox has no bound session file', async () => {
+    render(
+      <SandboxContextMenuPortal
+        menu={{ ...MENU, sessionFile: undefined }}
+        onClose={() => {}}
+        onListChange={() => {}}
+      />,
+    )
+    await act(async () => {
+      fireEvent.click(screen.getByText('common:sidebar.rename'))
+    })
+    expect(screen.queryByText('common:sidebar.autoGenerate')).toBeNull()
+  })
+})

--- a/src/renderer/src/features/workspace/sandbox-context-menu.tsx
+++ b/src/renderer/src/features/workspace/sandbox-context-menu.tsx
@@ -13,8 +13,8 @@ import {
 } from './context-menu-shared'
 import { RenamePromptDialog } from './rename-prompt-dialog'
 
-type MenuState = { x: number; y: number; path: string; label: string } | null
-type RenameState = { path: string; label: string } | null
+type MenuState = { x: number; y: number; path: string; label: string; sessionFile?: string } | null
+type RenameState = { path: string; label: string; sessionFile?: string } | null
 
 export function SandboxContextMenuPortal({
   menu,
@@ -93,7 +93,7 @@ export function SandboxContextMenuPortal({
                 onPointerDown={(e) => e.stopPropagation()}
                 onClick={(e) => {
                   e.stopPropagation()
-                  setRenameState({ path: menu.path, label: menu.label })
+                  setRenameState({ path: menu.path, label: menu.label, sessionFile: menu.sessionFile })
                   onClose()
                 }}
               >
@@ -118,6 +118,7 @@ export function SandboxContextMenuPortal({
         : null}
       <RenamePromptDialog
         open={!!renameState}
+        autoNameTarget={renameState?.sessionFile ? { sessionFile: renameState.sessionFile } : null}
         title={t('common:sidebar.renameTempChat')}
         defaultValue={renameState?.label ?? ''}
         onConfirm={submitRename}

--- a/src/renderer/src/features/workspace/session-context-menu.tsx
+++ b/src/renderer/src/features/workspace/session-context-menu.tsx
@@ -140,6 +140,7 @@ export function SessionContextMenuPortal({
         : null}
       <RenamePromptDialog
         open={!!renameTarget}
+        autoNameTarget={renameTarget?.sessionFile ? { sessionFile: renameTarget.sessionFile } : null}
         title={t('common:sidebar.renameSession')}
         defaultValue={renameDefault}
         onConfirm={submitRename}

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -30,6 +30,8 @@
     "firstMsgIsTitle": "First message is the title",
     "projects": "Projects",
     "rename": "Rename",
+    "autoGenerate": "Auto-generate",
+    "autoNameHint": "Extract title from the first message (strips / commands)",
     "delete": "Delete",
     "renamed": "Renamed",
     "renameFailed": "Rename failed",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -30,6 +30,8 @@
     "firstMsgIsTitle": "首条消息即标题",
     "projects": "项目",
     "rename": "重命名",
+    "autoGenerate": "自动生成",
+    "autoNameHint": "从首条消息提取标题（剥离 / 命令）",
     "delete": "删除",
     "renamed": "已重命名",
     "renameFailed": "重命名失败",


### PR DESCRIPTION
## 用户场景 / 问题
会话列表里全是"时间戳 + uuid 片段"式的默认标题，找不到想要的会话；手动一个个重命名太麻烦。

## 设计要点
**标题只写元数据，不重命名文件。** 会话文件路径是 TUI/app 共享的稳定键；标题通过 `session_info` 写入 JSONL（与 TUI `/name` 同机制，TUI 侧可见）+ configStore overlay。

## 方案（3 个提交）
1. 规则式标题生成：取首条用户消息，剥离行首 `/command`、剔除 URL 与文件路径、折叠空白、截断 ~40-50 字；通过 `session.autoName` IPC 写入（带测试）。
2. 重命名对话框内提供"自动生成"按钮（普通会话与 sandbox 会话均可用），已有人工命名时点自动生成则覆盖。
3. glossary/决策记录写入 doc/CONTEXT.md。