### PR TITLE
feat(timeline): activity window, non-message entries, and skill folding

### DIFF
--- a/doc/CONTEXT.md
+++ b/doc/CONTEXT.md
@@ -5,6 +5,40 @@
 侧栏项目列表默认按最近使用（MRU）排序：打开项目时 `configStore.addRecentProject` 把项目移到最前，且当前工作区始终置顶（`project-sidebar.tsx` 的 `diskPaths`）。新增配置项 `recentProjectsFixedOrder`（默认 `false`，保持 MRU 行为）：开启后 `nextRecentProjects` 不再移动已有项目（新项目追加到末尾），侧栏按存储顺序展示且当前项目不置顶（仅高亮）。纯函数：`src/main/recent-projects.ts`、`src/renderer/src/features/workspace/project-folder-order.ts`。设置页「最近项目」区开关直接写配置并派发 `pi-desktop:settings-changed` 事件通知侧栏即时重排。
 
 **闪烁根因（勿回退）**：`ui-store.setWorkspace` 曾把当前工作区 unshift 到 `recentProjects` 最前——固定模式下侧栏先跳顶，随后 `reloadSidebarSettings` 从主进程拉回真实顺序——先跳再弹回 = 每次切换可见闪烁。修复：`setWorkspace` 不再重排 `recentProjects`（侧栏顺序以主进程配置为唯一事实源；MRU 模式由 `projectFolderOrder` 的“当前置顶”规则兜底即时显示）。另：`reloadSidebarSettings` 在顺序无变化时保持数组引用稳定，避免固定模式下每次切换都触发整个侧栏重渲染。
+## 会话树交互术语（glossary）
+
+- **查看跳转（view-jump）**：单击会话树节点，时间线非破坏性定位到该节点对应的消息。历史未加载时先触发只读补拉，加载完成后再跳转；不改变会话叶子、不回退、不打断用户输入。
+- **回退（rewind）**：双击会话树节点或使用回退按钮，将会话当前位置移动到该节点（改变叶子，可再回退恢复）。
+- **全局统一**：右栏会话树面板与双击 Esc 的会话树浮层交互一致：单击或 Enter=查看跳转，双击=回退。
+
+### 决策记录：单击=查看、双击=回退（2026）
+
+会话树曾两次被改错：`a34ffa2` 把单击改成仅选中（“点击没反应”），后续提交又把单击改成直接回退（破坏性）。正确语义：**单击/Enter=非破坏性查看跳转**（时间线定位到该节点，不改叶子、不打扰输入；未加载的历史只读补拉并增量合并，时间线始终代表真实最新）；**双击=回退**（navigateTree）。勿再改为“单击=回退”。
+## 外部会话同步术语（glossary）
+
+- **外部更新（external update）**：非本 app worker 对会话 JSONL 的追加（典型：CLI 并发写同一会话）。app 空闲时**自动**把磁盘新尾部合并进时间线视图（不改变 worker 内存态）；同步状态由 composer 上方**三态指示器**呈现（见下）；完整手动刷新走右上角「刷新会话数据」按钮。
+
+### 决策记录：外部更新走视图层只读合并，不重载 worker（2026）
+
+CLI 与 app 同开一会话时，CLI 追加 JSONL。检测到外部更新后，app 只把磁盘新尾部合并进时间线视图（读路径 `session.getMessages` 本就磁盘直读、不依赖 worker），**绝不自动重载/覆盖 worker 内存态**——避免并发写互相覆盖与上下文丢失。监测机制：fs.watch 当前工作区会话目录（一个 watcher）+ 事件路由（命中当前会话→尾合并；新文件→刷新列表），切换会话只改路由；**定时轮询（~3s）兜底 Windows 丢事件**，另 debounce + 窗口聚焦时强制刷新。
+
+### 决策记录：外部同步用三态指示器，不做发送前确认弹窗（2026）
+
+实时同步已把磁盘尾部并入视图，弹窗冗余且打断输入。composer 上方**三态指示器**（`externalSyncPhase` 驱动）：外部写入合并成功 → **绿色脉冲「正在同步外部对话」**，约 5s 无外部写入自动隐藏（本轮结束）；IPC 同步异常 → **橙/红「外部同步异常」**，点击触发完整重载；空闲不渲染。**实现注意**：zustand `setState` 返回 `undefined`，判断"是否有新增"必须在 updater 内用局部变量捕获，不能靠返回值。
+
+### TODO：实时思考过程同步（等待 pi 支持流式落盘）
+
+pi CLI 的会话 JSONL 是**消息级落盘**（磁盘无流式中间条目，thinking+text+toolCall 同一条消息一次性 append）。因此 app 同步 CLI 会话的粒度上限 = 每条消息完成，CLI 思考过程中 app 看不到中间状态。**等 pi 支持思考块逐块落盘后**再回来做实时思考同步。勿再优化 watcher debounce/轮询间隔（那是消息级延迟，不是思考级）。
+## 会话显示特性术语（glossary）
+
+- **过程内容（activity item）**：时间线里非对话正文的条目——思考块（thinking）、工具调用行（tool-call，含命令执行）、skill 调用块。与对话正文（user/assistant 气泡）相对。
+- **活动窗口（activity window）**：过程内容的滚动展开窗口，大小 N 可在设置中配置。默认折叠所有过程内容，仅**自动展开最新 N 个**；有新增过程内容时，超出窗口的最旧项回到折叠态。**用户手动展开/折叠优先于窗口**（窗口不强制折叠用户明确展开的项）。N=0 表示禁用窗口（保持纯手动行为）。整个时间线统一计数，不按回合分界。
+- **元事件条目（non-message entry）**：`model_change` / `thinking_level_change` 等非消息 JSONL 条目。默认不展示；设置开关打开后，在时间线中以一行小字展示（如「切换到 acme/example-model · thinking: high」），相邻的 model+thinking 变更合并为一条。
+- **skill 调用块（skill invocation）**：以 `<skill name="..." location="...">` 开头的独立用户消息（pi 把 skill 内容作为用户消息注入）。渲染为一行折叠摘要「调用 skill: <name>」，点击展开全文；**默认折叠、不受活动窗口 N 限制**；摘要层不显示 location 路径（含本机用户名，避免泄漏）。
+
+### 决策记录：活动窗口与 skill/元事件展示（2026）
+
+时间线可读性与信息容积的权衡：过程内容全展开则 AI 执行时刷屏，全折叠则看不到进展。定案：**默认折叠 + 滑动窗口自动展开最新 N 个 + 手动优先**（见 glossary「活动窗口」）；skill 调用块单独折叠（默认折叠、不受窗口限制）；元事件条目默认隐藏、开关可开。这三类均为纯展示层行为，**开关与 N 存放 app 私有 config-store，不进 pi settings**。
 
 ## 进程边界
 

--- a/packages/shared/session-jsonl-timeline.ts
+++ b/packages/shared/session-jsonl-timeline.ts
@@ -65,8 +65,10 @@ export async function buildTimelinePageFromSessionFile(
     limit?: number
     leafId?: string | null
     activeSdkPath?: string | null
+    /** 是否把 model_change / thinking_level_change 元事件输出为时间线条目 */
+    showNonMessageEntries?: boolean
   },
-  timelineItemsFromBranchPath: (path: unknown[]) => Array<Record<string, unknown>>,
+  timelineItemsFromBranchPath: (path: unknown[], opts?: { showNonMessageEntries?: boolean }) => Array<Record<string, unknown>>,
 ): Promise<SessionTimelinePage> {
   const offset = Math.max(0, Number(opts.offset) || 0)
   const sm = await loadSessionManagerModule(opts.activeSdkPath)
@@ -83,7 +85,9 @@ export async function buildTimelinePageFromSessionFile(
   }
 
   const branchPath = smOpen.getBranch()
-  const all = timelineItemsFromBranchPath(branchPath)
+  const all = timelineItemsFromBranchPath(branchPath, {
+    showNonMessageEntries: opts.showNonMessageEntries === true,
+  })
   const totalCount = all.length
   const limit = Math.min(500, Math.max(1, Number(opts.limit) || totalCount || 1))
   const items = paginateItems(all, offset, limit)

--- a/packages/shared/timeline-settings.test.ts
+++ b/packages/shared/timeline-settings.test.ts
@@ -5,10 +5,10 @@ import {
 } from './timeline-settings'
 
 describe('normalizeTimelineMaxAutoExpandedTools', () => {
-  it('defaults invalid to 0 (Cursor-like collapsed tools)', () => {
+  it('defaults invalid to default window size', () => {
     expect(normalizeTimelineMaxAutoExpandedTools(undefined)).toBe(DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS)
     expect(normalizeTimelineMaxAutoExpandedTools('x')).toBe(DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS)
-    expect(DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS).toBe(0)
+    expect(DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS).toBe(5)
   })
 
   it('allows 0 and clamps to 0–50', () => {

--- a/packages/shared/timeline-settings.ts
+++ b/packages/shared/timeline-settings.ts
@@ -1,4 +1,11 @@
-export const DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS = 0
+/**
+ * 过程内容展开窗口（activity window）。
+ * 语义：时间线中的过程内容行（工具调用 / 思考块 / 命令执行）默认折叠，
+ * 仅自动展开最新的 N 个；新增过程内容时最旧的回到折叠态（滑动窗口）。
+ * 用户手动展开/折叠优先于窗口（见 timeline-tool-expand-policy.ts）。
+ * N=0 表示禁用窗口（全部保持手动行为）。
+ */
+export const DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS = 5
 export const TIMELINE_MAX_AUTO_EXPANDED_TOOLS_MIN = 0
 export const TIMELINE_MAX_AUTO_EXPANDED_TOOLS_MAX = 50
 

--- a/src/main/config-store.ts
+++ b/src/main/config-store.ts
@@ -49,8 +49,10 @@ export interface StoreSchema {
   maxSessionWorkers: number
   /** 空闲 worker 回收时间（分钟）；0 = 不因超时回收 */
   sessionWorkerIdleTimeoutMinutes: number
-  /** 时间线当前 run 内同时自动展开的工具详情数量上限 */
+  /** 时间线过程内容（工具/思考）滑动窗口大小；0 = 禁用自动展开 */
   timelineMaxAutoExpandedTools: number
+  /** 时间线是否展示元事件条目（model_change / thinking_level_change）；默认隐藏 */
+  showNonMessageEntries: boolean
   /** 侧栏会话显示名，键为规范化后的 sessionFile 绝对路径 */
   sessionDisplayNames: Record<string, string>
   /** 语音输入 ASR 配置 */
@@ -95,6 +97,7 @@ const store = new Store<StoreSchema>({
     maxSessionWorkers: 4,
     sessionWorkerIdleTimeoutMinutes: 15,
     timelineMaxAutoExpandedTools: DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS,
+    showNonMessageEntries: false,
     sessionDisplayNames: {},
     asrConfig: {
       provider: 'codex-asr-builtin',

--- a/src/main/ipc/handlers/session.ts
+++ b/src/main/ipc/handlers/session.ts
@@ -259,6 +259,9 @@ export function registerSessionHandlers(): void {
         offset,
         limit: limit || undefined,
         leafId,
+        // 元事件展示开关是 app 私有设置，主进程直接读 config-store，
+        // renderer 调用方无需逐调用透传
+        showNonMessageEntries: configStore.get('showNonMessageEntries') === true,
       })
       return {
         items: disk.items,

--- a/src/main/session-messages-from-disk.ts
+++ b/src/main/session-messages-from-disk.ts
@@ -10,6 +10,7 @@ export async function getSessionMessagesFromDisk(
   limit?: number,
   leafId?: string | null,
   activeSdkPath?: string | null,
+  opts?: { showNonMessageEntries?: boolean },
 ): Promise<{
   items: Array<Record<string, unknown>>
   totalCount: number
@@ -17,7 +18,7 @@ export async function getSessionMessagesFromDisk(
 }> {
   return buildTimelinePageFromSessionFile(
     sessionFile,
-    { offset, limit, leafId, activeSdkPath },
+    { offset, limit, leafId, activeSdkPath, showNonMessageEntries: opts?.showNonMessageEntries },
     timelineItemsFromBranchPath,
   )
 }

--- a/src/main/session-preview-process.ts
+++ b/src/main/session-preview-process.ts
@@ -173,6 +173,7 @@ export class SessionPreviewProcess {
     offset: number
     limit?: number
     leafId?: string | null
+    showNonMessageEntries?: boolean
   }): Promise<DiskSessionMessages> {
     return this.request('session.getMessages', { ...payload, cwd: payload.cwd })
   }

--- a/src/preview/index.ts
+++ b/src/preview/index.ts
@@ -53,6 +53,7 @@ process.parentPort.on('message', async (event: { data?: PreviewRequest } | Previ
         message.payload.limit == null ? undefined : Number(message.payload.limit),
         message.payload.leafId as string | null | undefined,
         message.activeSdkPath,
+        message.payload.showNonMessageEntries === true ? { showNonMessageEntries: true } : undefined,
       )
     } else if (message.type === 'session.tree') {
       result = await flattenTreeFromSessionFile(
@@ -60,6 +61,7 @@ process.parentPort.on('message', async (event: { data?: PreviewRequest } | Previ
         String(message.payload.cwd || ''),
         message.payload.leafId as string | null | undefined,
         message.activeSdkPath,
+        message.payload.showNonMessageEntries === true ? { showNonMessageEntries: true } : undefined,
       )
     } else if (message.type === 'pi.settings.set') {
       const sdk = message.activeSdkPath

--- a/src/preview/wsl.ts
+++ b/src/preview/wsl.ts
@@ -60,6 +60,7 @@ async function handleRequest(message: WslPreviewRequest): Promise<void> {
         message.limit == null ? undefined : Number(message.limit),
         message.leafId as string | null | undefined,
         message.sdkPath,
+        message.showNonMessageEntries === true ? { showNonMessageEntries: true } : undefined,
       )
     } else if (message.type === 'session.tree') {
       result = await flattenTreeFromSessionFile(
@@ -67,6 +68,7 @@ async function handleRequest(message: WslPreviewRequest): Promise<void> {
         String(message.cwd || ''),
         message.leafId as string | null | undefined,
         message.sdkPath,
+        message.showNonMessageEntries === true ? { showNonMessageEntries: true } : undefined,
       )
     } else if (message.type === 'pi.settings.set') {
       const sdk = await import(message.sdkPath)

--- a/src/renderer/src/app/app.tsx
+++ b/src/renderer/src/app/app.tsx
@@ -169,6 +169,12 @@ export default function App() {
         })
         .catch(() => {})
       prefetchAvailableModels()
+      void ipcClient
+        .invoke('settings.get', { key: 'showNonMessageEntries' })
+        .then((res) => {
+          useUIStore.getState().setShowNonMessageEntries(res?.settings?.showNonMessageEntries === true)
+        })
+        .catch(() => {})
     })
     return () => cancelAnimationFrame(frame)
   }, [applyRightPanelRuntime])
@@ -194,6 +200,7 @@ export default function App() {
     return () => {
       unsubEvents()
       unsubExit()
+
     }
   }, [setWorkspace])
 

--- a/src/renderer/src/features/settings/__tests__/custom-theme-draft.test.ts
+++ b/src/renderer/src/features/settings/__tests__/custom-theme-draft.test.ts
@@ -18,6 +18,7 @@ vi.mock('@renderer/stores/ui-store', () => ({
     getState: () => ({
       setTheme: vi.fn(),
       setTimelineMaxAutoExpandedTools: vi.fn(),
+      setShowNonMessageEntries: vi.fn(),
       applyRightPanelRuntime: vi.fn(),
     }),
   },
@@ -40,6 +41,7 @@ function draft(): SettingsDraft {
     maxSessionWorkers: 4,
     sessionWorkerIdleTimeoutMinutes: 15,
     timelineMaxAutoExpandedTools: 3,
+    showNonMessageEntries: false,
     extensionOverrides: {},
     rightPanelCatalog: [],
     rightPanelPrefs: {},

--- a/src/renderer/src/features/settings/appearance-theme-editor.test.tsx
+++ b/src/renderer/src/features/settings/appearance-theme-editor.test.tsx
@@ -50,6 +50,7 @@ function baseDraft(): SettingsDraft {
     maxSessionWorkers: 4,
     sessionWorkerIdleTimeoutMinutes: 15,
     timelineMaxAutoExpandedTools: 0,
+    showNonMessageEntries: false,
     extensionOverrides: {},
     rightPanelCatalog: [],
     rightPanelPrefs: {},

--- a/src/renderer/src/features/settings/settings-draft-context.tsx
+++ b/src/renderer/src/features/settings/settings-draft-context.tsx
@@ -65,6 +65,8 @@ type SettingsDraftContextValue = {
   setSessionWorkerIdleTimeoutMinutes: (n: number) => void
   setTimelineMaxAutoExpandedTools: (n: number) => void
   setAgentRuntime: (r: AgentRuntimeChoice) => void
+
+  setShowNonMessageEntries: (v: boolean) => void
   setExtensionOverride: (id: string, enabled: boolean) => void
   setRightPanelPref: (id: string, on: boolean) => void
   reorderRightPanels: (fromId: string, toIndex: number) => void
@@ -267,6 +269,8 @@ export function SettingsDraftProvider({ children }: { children: ReactNode }) {
           timelineMaxAutoExpandedTools: normalizeTimelineMaxAutoExpandedTools(n),
         })),
       setAgentRuntime: (r) => patch((d) => ({ ...d, agentRuntime: r })),
+
+      setShowNonMessageEntries: (v) => patch((d) => ({ ...d, showNonMessageEntries: v === true })),
       setExtensionOverride: (id, enabled) =>
         patch((d) => ({
           ...d,

--- a/src/renderer/src/features/settings/settings-draft.ts
+++ b/src/renderer/src/features/settings/settings-draft.ts
@@ -41,6 +41,7 @@ export type SettingsDraft = {
   maxSessionWorkers: number
   sessionWorkerIdleTimeoutMinutes: number
   timelineMaxAutoExpandedTools: number
+  showNonMessageEntries: boolean
   extensionOverrides: Record<string, boolean>
   rightPanelCatalog: RightPanelCatalogItem[]
   rightPanelPrefs: RightPanelPrefs
@@ -106,6 +107,7 @@ export function draftSignature(d: SettingsDraft): string {
     maxSessionWorkers: d.maxSessionWorkers,
     sessionWorkerIdleTimeoutMinutes: d.sessionWorkerIdleTimeoutMinutes,
     timelineMaxAutoExpandedTools: d.timelineMaxAutoExpandedTools,
+    showNonMessageEntries: d.showNonMessageEntries,
     extensionOverrides: d.extensionOverrides,
     rightPanelPrefs: d.rightPanelPrefs,
     rightPanelOrder: d.rightPanelOrder,
@@ -140,6 +142,7 @@ export async function loadSettingsDraftFromDisk(i18nLanguage: string): Promise<S
     maxSessionWorkers: normalizeMaxSessionWorkersUi(s.maxSessionWorkers),
     sessionWorkerIdleTimeoutMinutes: normalizeIdleTimeoutMinutesUi(s.sessionWorkerIdleTimeoutMinutes),
     timelineMaxAutoExpandedTools: normalizeTimelineMaxAutoExpandedTools(s.timelineMaxAutoExpandedTools),
+    showNonMessageEntries: s.showNonMessageEntries === true,
     extensionOverrides: { ...(s.extensionOverrides || {}) },
     rightPanelCatalog: cat,
     rightPanelPrefs: prefs,
@@ -261,6 +264,10 @@ export async function commitSettingsDraft(draft: SettingsDraft, i18n: I18n): Pro
     key: 'timelineMaxAutoExpandedTools',
     value: draft.timelineMaxAutoExpandedTools,
   })
+  await ipcClient.invoke('settings.set', {
+    key: 'showNonMessageEntries',
+    value: draft.showNonMessageEntries,
+  })
   await ipcClient.invoke('settings.set', { key: 'extensionOverrides', value: draft.extensionOverrides })
   await ipcClient.invoke('rightPanels.saveLayout', {
     prefs: draft.rightPanelPrefs,
@@ -276,6 +283,7 @@ export async function commitSettingsDraft(draft: SettingsDraft, i18n: I18n): Pro
   useUIStore.getState().setTheme(draft.theme)
   applyIconTheme(draft.iconTheme)
   useUIStore.getState().setTimelineMaxAutoExpandedTools(draft.timelineMaxAutoExpandedTools)
+  useUIStore.getState().setShowNonMessageEntries(draft.showNonMessageEntries)
   applyThemeToDocument(draft.theme)
   applyCustomTheme(draft.customTheme)
   injectCustomCssOverride(draft.customCssOverride)

--- a/src/renderer/src/features/settings/settings-general-appearance.tsx
+++ b/src/renderer/src/features/settings/settings-general-appearance.tsx
@@ -277,7 +277,8 @@ export function GeneralSettings() {
 
 export function AppearanceSettings() {
   const { t } = useTranslation()
-  const { draft, setTheme, setIconTheme, setTimelineMaxAutoExpandedTools } = useSettingsDraft()
+  const { draft, setTheme, setIconTheme, setTimelineMaxAutoExpandedTools, setShowNonMessageEntries } =
+    useSettingsDraft()
 
   const themes: { key: 'light' | 'dark' | 'system'; icon: AppIconComponent }[] = [
     { key: 'light', icon: Sun },
@@ -362,6 +363,15 @@ export function AppearanceSettings() {
               setTimelineMaxAutoExpandedTools(n)
             }}
             className={numberInputCls}
+          />
+        </SettingRow>
+        <SettingRow
+          label={t('settings:appearance.showNonMessageEntries')}
+          description={t('settings:appearance.showNonMessageEntriesDesc')}
+        >
+          <Switch
+            checked={draft.showNonMessageEntries}
+            onCheckedChange={setShowNonMessageEntries}
           />
         </SettingRow>
       </SettingsSection>

--- a/src/renderer/src/features/timeline/skill-invocation-row.test.ts
+++ b/src/renderer/src/features/timeline/skill-invocation-row.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { isSkillInvocationMessage, parseSkillInvocationName } from './skill-invocation-row'
+
+describe('skill invocation detection', () => {
+  it('detects a skill-wrapped user message', () => {
+    const text =
+      '<skill name="batch-grill-with-docs" location="~/.agents/skills/batch-grill-with-docs/SKILL.md">\n# Batch Grill with Docs'
+    expect(isSkillInvocationMessage(text)).toBe(true)
+    expect(parseSkillInvocationName(text)).toBe('batch-grill-with-docs')
+  })
+
+  it('rejects ordinary user messages', () => {
+    expect(isSkillInvocationMessage('hello world')).toBe(false)
+    expect(isSkillInvocationMessage('')).toBe(false)
+    expect(isSkillInvocationMessage('<skillz>not a skill</skillz>')).toBe(false)
+  })
+
+  it('tolerates leading whitespace', () => {
+    expect(isSkillInvocationMessage('  <skill name="x" location="y">')).toBe(true)
+  })
+})

--- a/src/renderer/src/features/timeline/skill-invocation-row.tsx
+++ b/src/renderer/src/features/timeline/skill-invocation-row.tsx
@@ -1,0 +1,66 @@
+import { memo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronRight } from '@renderer/components/icons'
+import { cn } from '@renderer/lib/utils'
+import { normalizeSessionFileKey } from '@renderer/lib/session-file-key'
+import { useUIStore } from '@renderer/stores/ui-store'
+import type { TimelineItem } from '@renderer/stores/ui-store-types'
+
+const SKILL_OPEN_RE = /^<skill\s+name="([^"]*)"/
+
+export function parseSkillInvocationName(text: string): string | undefined {
+  const m = SKILL_OPEN_RE.exec(String(text || '').trimStart())
+  return m?.[1] || undefined
+}
+
+export function isSkillInvocationMessage(text: string): boolean {
+  return SKILL_OPEN_RE.test(String(text || '').trimStart())
+}
+
+/**
+ * skill 调用折叠行：pi 把 skill 内容作为独立用户消息注入（`<skill name=...>` 开头）。
+ * 摘要一行（默认折叠），点击展开全文。不受滑动窗口 N 限制；展开状态按会话记忆。
+ */
+export const SkillInvocationRow = memo(function SkillInvocationRow({
+  item,
+}: {
+  item: TimelineItem
+}) {
+  const { t } = useTranslation()
+  const itemId = String(item.id)
+  const expanded = useUIStore((s) => {
+    const sessionKey =
+      normalizeSessionFileKey(s.historySessionFile || '') ||
+      s.historySessionFile ||
+      '__none__'
+    return s.skillExpandBySession[sessionKey]?.[itemId]
+  })
+  const setExpanded = useUIStore((s) => s.setSkillInvocationExpanded)
+  const name = parseSkillInvocationName(String(item.text || ''))
+  const open = expanded === true
+
+  return (
+    <div className="mb-0">
+      <button
+        type="button"
+        onClick={() => setExpanded(itemId, open ? false : true)}
+        className="timeline-activity-row"
+      >
+        <ChevronRight
+          className={cn('chevron-expand h-3 w-3 timeline-text-placeholder', open && 'rotate-90')}
+        />
+        <span className="timeline-activity-label timeline-skill-invocation-label">
+          {t('timeline:skillInvoked', { name: name || t('timeline:skillUnknown') })}
+        </span>
+      </button>
+      {open ? (
+        <div
+          data-independent-scroll
+          className="timeline-skill-invocation-body ml-3.5 max-h-48 overflow-y-auto overscroll-contain whitespace-pre-wrap break-words border-l border-border/35 pl-2 font-mono text-[12px] leading-[1.55] text-foreground-secondary"
+        >
+          {String(item.text || '')}
+        </div>
+      ) : null}
+    </div>
+  )
+})

--- a/src/renderer/src/features/timeline/thinking-chain-block.tsx
+++ b/src/renderer/src/features/timeline/thinking-chain-block.tsx
@@ -36,6 +36,7 @@ export function ThinkingChainBlock({
   duration,
   labelSeed,
   placeholder = false,
+  autoExpanded = false,
 }: {
   text: string
   streaming?: boolean
@@ -44,10 +45,13 @@ export function ThinkingChainBlock({
   duration?: number
   labelSeed?: string
   placeholder?: boolean
+  /** 滑动窗口自动展开；用户手动折叠优先（点击后以手动状态为准） */
+  autoExpanded?: boolean
 }) {
   const { t } = useTranslation()
-  const [userOpen, setUserOpen] = useState(false)
-  const open = userOpen && !placeholder
+  // undefined = 用户未操作（跟随窗口）；false = 手动折叠；true = 手动展开（永远优先）
+  const [userOpen, setUserOpen] = useState<boolean | undefined>(undefined)
+  const open = (userOpen === undefined ? autoExpanded : userOpen) && !placeholder
   const startedAtRef = useRef<number | null>(startedAt ?? null)
   const [elapsedMs, setElapsedMs] = useState(0)
   const body = text.trim()
@@ -102,7 +106,8 @@ export function ThinkingChainBlock({
         type="button"
         onClick={() => {
           if (placeholder || !body) return
-          setUserOpen((prev) => !prev)
+          // 手动优先：点击即记录用户意图，窗口不再覆盖
+          setUserOpen(!open)
         }}
         className={cn(
           'timeline-activity-row',

--- a/src/renderer/src/features/timeline/timeline-activity-window.test.tsx
+++ b/src/renderer/src/features/timeline/timeline-activity-window.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Timeline } from './timeline'
+import { useUIStore } from '@renderer/stores/ui-store'
+import { ipcClient } from '@renderer/lib/ipc-client'
+import type { TimelineItem } from '@renderer/stores/ui-store-types'
+
+vi.mock('@renderer/lib/ipc-client', () => ({
+  ipcClient: { invoke: vi.fn(async () => ({ items: [], totalCount: 0, sourceCount: 0 })) },
+}))
+vi.mock('@renderer/lib/session-rewind', () => ({ navigateSessionToEntry: vi.fn(async () => true) }))
+vi.mock('@renderer/lib/session-fork', () => ({ forkSessionFromEntry: vi.fn(async () => true) }))
+vi.mock('@renderer/lib/reload-current-session-data', () => ({
+  reloadCurrentSessionData: vi.fn(async () => {}),
+}))
+vi.mock('@renderer/lib/session-chrome', () => ({
+  useSessionChrome: () => ({ canStop: false, showSpinner: false, sessionKey: '/tmp/proj/s.jsonl' }),
+}))
+
+function baseState(overrides: Record<string, unknown> = {}) {
+  return {
+    currentWorkspace: '/tmp/proj',
+    historySessionFile: '/tmp/proj/s.jsonl',
+    timelineItems: [] as TimelineItem[],
+    historyTotalCount: 0,
+    historyLoadedCount: 0,
+    historyLoading: false,
+    streamingAssistantId: null,
+    optimisticPendingUserText: null,
+    agentTurnBootstrapping: false,
+    runState: { status: 'idle' } as never,
+    sessionRuntimeRunning: {},
+    workerLiveSnapshot: { status: 'idle' } as never,
+    timelineMaxAutoExpandedTools: 5,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useUIStore.setState(baseState())
+  vi.mocked(ipcClient.invoke).mockClear()
+  const origAnimate = Element.prototype.animate
+  Element.prototype.animate = vi.fn(
+    () => ({ finished: Promise.resolve(), cancel: vi.fn() }) as unknown as Animation,
+  )
+  return () => {
+    Element.prototype.animate = origAnimate
+  }
+})
+
+const thinkingRow = (id: string, text: string): TimelineItem =>
+  ({
+    id,
+    type: 'assistant-message',
+    thinkingText: text,
+    text: '',
+    timestamp: 1000,
+    sessionEntryId: id,
+  }) as TimelineItem
+
+describe('activity window auto-expand', () => {
+  it('expands the newest thinking rows within the window, collapses older ones', async () => {
+    const items = [
+      thinkingRow('old-1', 'OLD THINKING ONE'),
+      thinkingRow('old-2', 'OLD THINKING TWO'),
+      thinkingRow('new-1', 'NEW THINKING ONE'),
+      thinkingRow('new-2', 'NEW THINKING TWO'),
+    ]
+    useUIStore.setState(
+      baseState({
+        timelineItems: items,
+        historyTotalCount: items.length,
+        historyLoadedCount: items.length,
+        timelineMaxAutoExpandedTools: 2,
+      }),
+    )
+    render(<Timeline />)
+    await waitFor(() => expect(screen.getByText('NEW THINKING TWO')).toBeTruthy())
+    expect(screen.getByText('NEW THINKING ONE')).toBeTruthy()
+    expect(screen.queryByText('OLD THINKING TWO')).toBeNull()
+    expect(screen.queryByText('OLD THINKING ONE')).toBeNull()
+  })
+
+  it('window size 0 disables auto-expand entirely', async () => {
+    const items = [
+      thinkingRow('a', 'ONLY THINKING'),
+      thinkingRow('b', 'LAST THINKING'),
+    ]
+    useUIStore.setState(
+      baseState({
+        timelineItems: items,
+        historyTotalCount: items.length,
+        historyLoadedCount: items.length,
+        timelineMaxAutoExpandedTools: 0,
+      }),
+    )
+    render(<Timeline />)
+    await waitFor(() => expect(screen.queryByText('LAST THINKING')).toBeNull())
+  })
+
+  it('auto-expands a tool group when any of its tools hits the window budget', async () => {
+    const toolRow = (id: string, name: string): TimelineItem =>
+      ({
+        id,
+        type: 'tool-call',
+        toolName: name,
+        toolPhase: 'end',
+        toolArgs: {},
+        toolOutput: '',
+        timestamp: 1000,
+        sessionEntryId: id,
+      }) as TimelineItem
+    const items = [
+      toolRow('t1', 'bash'),
+      toolRow('t2', 'read'),
+      // 段封：工具后跟随 prose → 工具行合并为一个 tool-group
+      ({ id: 'p1', type: 'assistant-message', text: 'done', timestamp: 2000, sessionEntryId: 'p1' }) as TimelineItem,
+    ]
+    useUIStore.setState(
+      baseState({
+        timelineItems: items,
+        historyTotalCount: items.length,
+        historyLoadedCount: items.length,
+        timelineMaxAutoExpandedTools: 2,
+      }),
+    )
+    render(<Timeline />)
+    await waitFor(() => {
+      const groupBtn = document.querySelector('.tool-group-hit') as HTMLElement | null
+      expect(groupBtn?.getAttribute('aria-expanded')).toBe('true')
+    })
+    // 组展开后工具行内容可见
+    expect(screen.getByText('bash')).toBeTruthy()
+    expect(screen.getByText('read')).toBeTruthy()
+  })
+
+  it('keeps tool groups collapsed when the window is disabled', async () => {
+    const toolRow = (id: string, name: string): TimelineItem =>
+      ({
+        id,
+        type: 'tool-call',
+        toolName: name,
+        toolPhase: 'end',
+        toolArgs: {},
+        toolOutput: '',
+        timestamp: 1000,
+        sessionEntryId: id,
+      }) as TimelineItem
+    const items = [
+      toolRow('t1', 'bash'),
+      toolRow('t2', 'read'),
+      ({ id: 'p1', type: 'assistant-message', text: 'done', timestamp: 2000, sessionEntryId: 'p1' }) as TimelineItem,
+    ]
+    useUIStore.setState(
+      baseState({
+        timelineItems: items,
+        historyTotalCount: items.length,
+        historyLoadedCount: items.length,
+        timelineMaxAutoExpandedTools: 0,
+      }),
+    )
+    render(<Timeline />)
+    await waitFor(() => {
+      const groupBtn = document.querySelector('.tool-group-hit') as HTMLElement | null
+      expect(groupBtn?.getAttribute('aria-expanded')).toBe('false')
+    })
+  })
+})

--- a/src/renderer/src/features/timeline/timeline-tool-expand-policy.test.ts
+++ b/src/renderer/src/features/timeline/timeline-tool-expand-policy.test.ts
@@ -1,65 +1,50 @@
 import { describe, expect, it } from 'vitest'
-import { pickAutoExpandedToolIds } from './timeline-tool-expand-policy'
+import { pickAutoExpandedActivityIds } from './timeline-tool-expand-policy'
 
-function slot(id: string, runId = 'run-1', toolPhase = 'end') {
-  return { id, runId, toolPhase }
+function slot(id: string, kind: 'tool' | 'thinking' = 'tool') {
+  return { id, kind }
 }
 
-describe('pickAutoExpandedToolIds', () => {
-  it('returns empty when agent not running', () => {
-    const ids = pickAutoExpandedToolIds([slot('a')], {
-      agentRunning: false,
-      activeRunId: 'run-1',
-      maxExpanded: 15,
-    })
+describe('pickAutoExpandedActivityIds', () => {
+  it('returns empty when maxExpanded is 0 (window disabled)', () => {
+    const slots = Array.from({ length: 5 }, (_, i) => slot(`t${i}`))
+    const ids = pickAutoExpandedActivityIds(slots, { maxExpanded: 0 })
     expect(ids.size).toBe(0)
   })
 
-  it('returns empty when maxExpanded is 0', () => {
-    const slots = Array.from({ length: 5 }, (_, i) => slot(`t${i}`, 'run-1', 'update'))
-    const ids = pickAutoExpandedToolIds(slots, {
-      agentRunning: true,
-      activeRunId: 'run-1',
-      maxExpanded: 0,
-    })
-    expect(ids.size).toBe(0)
+  it('returns empty on empty slots', () => {
+    expect(pickAutoExpandedActivityIds([], { maxExpanded: 15 }).size).toBe(0)
   })
 
-  it('keeps only last N tools of current run', () => {
+  it('keeps only the newest N activity rows (sliding window tail)', () => {
     const slots = Array.from({ length: 20 }, (_, i) => slot(`t${i}`))
-    const ids = pickAutoExpandedToolIds(slots, {
-      agentRunning: true,
-      activeRunId: 'run-1',
-      maxExpanded: 15,
-    })
+    const ids = pickAutoExpandedActivityIds(slots, { maxExpanded: 15 })
     expect(ids.size).toBe(15)
     expect(ids.has('t19')).toBe(true)
     expect(ids.has('t4')).toBe(false)
     expect(ids.has('t0')).toBe(false)
   })
 
-  it('includes completed tools in the budget while agent is running', () => {
+  it('counts thinking rows in the same window as tools', () => {
     const slots = [
-      slot('done', 'run-1', 'end'),
-      slot('live', 'run-1', 'update'),
+      slot('think-1', 'thinking'),
+      slot('tool-1', 'tool'),
+      slot('think-2', 'thinking'),
+      slot('tool-2', 'tool'),
     ]
-    const ids = pickAutoExpandedToolIds(slots, {
-      agentRunning: true,
-      activeRunId: 'run-1',
-      maxExpanded: 15,
-    })
-    expect(ids.has('live')).toBe(true)
-    expect(ids.has('done')).toBe(true)
+    const ids = pickAutoExpandedActivityIds(slots, { maxExpanded: 2 })
+    expect(ids.size).toBe(2)
+    expect(ids.has('think-2')).toBe(true)
+    expect(ids.has('tool-2')).toBe(true)
+    expect(ids.has('think-1')).toBe(false)
+    expect(ids.has('tool-1')).toBe(false)
   })
 
-  it('ignores tools from other runs', () => {
-    const slots = [slot('other', 'run-old', 'end'), slot('cur', 'run-1', 'end')]
-    const ids = pickAutoExpandedToolIds(slots, {
-      agentRunning: true,
-      activeRunId: 'run-1',
-      maxExpanded: 15,
-    })
-    expect(ids.has('cur')).toBe(true)
-    expect(ids.has('other')).toBe(false)
+  it('window is static — not tied to agent running or run id', () => {
+    const slots = [slot('a'), slot('b'), slot('c')]
+    const ids = pickAutoExpandedActivityIds(slots, { maxExpanded: 2 })
+    expect(ids.has('c')).toBe(true)
+    expect(ids.has('b')).toBe(true)
+    expect(ids.has('a')).toBe(false)
   })
 })

--- a/src/renderer/src/features/timeline/timeline-tool-expand-policy.ts
+++ b/src/renderer/src/features/timeline/timeline-tool-expand-policy.ts
@@ -8,31 +8,26 @@ export const TIMELINE_MAX_AUTO_EXPANDED_TOOLS = DEFAULT_TIMELINE_MAX_AUTO_EXPAND
 
 export { normalizeTimelineMaxAutoExpandedTools }
 
-export type ToolExpandSlot = {
+export type ActivityExpandSlot = {
   id: string
-  runId?: string
-  toolPhase?: string
+  /** 过程行类别：tool-call（工具调用/命令执行）或 thinking（思考块） */
+  kind: 'tool' | 'thinking'
 }
 
 /**
- * Auto-expand budget for tools in the active run.
- * maxExpanded=0 → never auto-expand.
- * While agent is running: expand the last N tools of the current run (any phase).
- * User click override lives in toolExpandBySession and always wins in ToolCallRow.
+ * 过程内容滑动窗口（activity window）。
+ * 时间线中过程行默认折叠，仅自动展开**最新**的 N 个；有新增时最旧的回到折叠态。
+ * 整个时间线统一计数（不按回合分界），静态生效——与 agent 是否在运行无关，
+ * 历史会话回放时同样只展开尾部 N 个。
+ * maxExpanded=0 → 窗口禁用（全部保持手动行为）。
+ * 用户手动展开/折叠（toolExpandBySession）在 ToolCallRow / ThinkingChainBlock 中永远优先。
  */
-export function pickAutoExpandedToolIds(
-  slots: ToolExpandSlot[],
-  opts: {
-    agentRunning: boolean
-    activeRunId: string | null | undefined
-    maxExpanded?: number
-  },
+export function pickAutoExpandedActivityIds(
+  slots: ActivityExpandSlot[],
+  opts: { maxExpanded?: number },
 ): Set<string> {
   const max = opts.maxExpanded ?? DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS
   if (max <= 0) return new Set()
-  if (!opts.agentRunning || !opts.activeRunId) return new Set()
-
-  const runSlots = slots.filter((slot) => slot.runId && slot.runId === opts.activeRunId)
-  const tail = runSlots.slice(-max)
-  return new Set(tail.map((slot) => slot.id))
+  if (slots.length === 0) return new Set()
+  return new Set(slots.slice(-max).map((slot) => slot.id))
 }

--- a/src/renderer/src/features/timeline/timeline.tsx
+++ b/src/renderer/src/features/timeline/timeline.tsx
@@ -14,6 +14,7 @@ import { SessionOpenLoadingView } from './session-open-loading'
 import { ThinkingChainBlock } from './thinking-chain-block'
 import { ToolCallRow } from './tool-call-row'
 import { ToolGroupSummary } from './tool-group-summary'
+import { SkillInvocationRow, isSkillInvocationMessage } from './skill-invocation-row'
 import { buildTimelineDisplayItems, type TimelineDisplayItem, type TimelineRawItem } from './timeline-display-items'
 import { MessageHoverActions, MessageHoverShell } from './message-hover-actions'
 import { registerTimelineScrollEl } from './timeline-scroll-bridge'
@@ -34,7 +35,7 @@ import { useExtensionUIStore } from '@renderer/stores/extension-ui-store'
 import { useTimelineBottomAnchorController } from './timeline-bottom-anchor'
 import { TimelineBottomAnchorButton } from './timeline-bottom-anchor-button'
 import { splitTimelineRenderSegments, sliceHistoryForViewport } from './timeline-render-segments'
-import { pickAutoExpandedToolIds } from './timeline-tool-expand-policy'
+import { pickAutoExpandedActivityIds } from './timeline-tool-expand-policy'
 import { groupDisplayBlocksByTurn } from './timeline-turn-groups'
 import { TurnActivityBlock } from './turn-activity-block'
 import { shouldShowTimelineHonestyBanner } from '@renderer/lib/timeline-honesty'
@@ -53,6 +54,8 @@ const TimelineItemBase = memo(function TimelineItem({
   agentRunning,
   agentBoot,
   rewindEntryId,
+  /** 滑动窗口：该行是否被窗口自动展开（思考块用） */
+  autoExpanded = false,
   /** Only the last prose leaf of a turn (or user) should expose copy/rewind chrome. */
   showMessageActions = true,
 }: {
@@ -63,6 +66,7 @@ const TimelineItemBase = memo(function TimelineItem({
   agentBoot: boolean
   /** Pre-resolved incomplete-assistant / user rewind target for this row */
   rewindEntryId?: string
+  autoExpanded?: boolean
   showMessageActions?: boolean
 }) {
   const { t } = useTranslation()
@@ -70,6 +74,14 @@ const TimelineItemBase = memo(function TimelineItem({
     rewindEntryId ?? (row.sessionEntryId as string | undefined)
 
   if (item.type === 'user-message') {
+    // skill 调用：pi 把 skill 内容作为独立用户消息注入，折叠为一行摘要（默认折叠、不受窗口限制）
+    if (isSkillInvocationMessage(String(item.text || ''))) {
+      return (
+        <div className="timeline-message-row timeline-activity-item">
+          <SkillInvocationRow item={item as unknown as TimelineItem} />
+        </div>
+      )
+    }
     const segments: Segment[] = (item.segments as Segment[] | undefined)?.length
       ? (item.segments as Segment[])
       : [{ type: 'text', text: String(item.text || '') }]
@@ -182,6 +194,7 @@ const TimelineItemBase = memo(function TimelineItem({
           <ThinkingChainBlock
             text={String(item.thinkingText ?? '')}
             streaming={streaming}
+            autoExpanded={autoExpanded}
             startedAt={Number(item.timestamp ?? 0) || undefined}
             duration={Number(item.thinkingDuration ?? 0) || undefined}
             labelSeed={String(item.id)}
@@ -196,6 +209,7 @@ const TimelineItemBase = memo(function TimelineItem({
           <ThinkingChainBlock
             text={String(item.thinkingText ?? '')}
             streaming={streaming}
+            autoExpanded={autoExpanded}
             startedAt={Number(item.timestamp ?? 0) || undefined}
             duration={Number(item.thinkingDuration ?? 0) || undefined}
             labelSeed={String(item.id)}
@@ -305,6 +319,24 @@ const TimelineItemBase = memo(function TimelineItem({
             {String(item.text)}
           </pre>
         )}
+      </div>
+    )
+  }
+
+  if (item.type === 'model-change') {
+    const meta = item as unknown as TimelineItem & { model?: string; thinkingLevel?: string }
+    const parts: string[] = []
+    if (meta.model) parts.push(t('timeline:modelChangeTo', { model: meta.model }))
+    if (meta.thinkingLevel) {
+      parts.push(t('timeline:thinkingLevelChangeTo', { level: meta.thinkingLevel }))
+    }
+    if (parts.length === 0) return null
+    return (
+      <div className="timeline-message-row timeline-activity-item">
+        <div className="flex items-center gap-1.5 px-0.5 text-[11px] timeline-text-quiet">
+          <span aria-hidden className="h-1 w-1 rounded-full bg-border" />
+          <span>{parts.join(' · ')}</span>
+        </div>
       </div>
     )
   }
@@ -499,21 +531,27 @@ export function Timeline() {
   const toolExpandSlots = useMemo(
     () =>
       visibleItems
-        .filter((row) => row.type === 'tool-call')
+        .filter(
+          (row) =>
+            row.type === 'tool-call' ||
+            (row.type === 'assistant-message' &&
+              !!String((row as { thinkingText?: string }).thinkingText ?? '').trim()),
+        )
         .map((row) => {
           const toolRow = row as ToolTimelineItem
-          return { id: toolRow.id, runId: toolRow.runId, toolPhase: toolRow.toolPhase }
+          return {
+            id: toolRow.id,
+            kind: row.type === 'assistant-message' ? ('thinking' as const) : ('tool' as const),
+          }
         }),
     [visibleItems],
   )
   const autoExpandedToolIds = useMemo(
     () =>
-      pickAutoExpandedToolIds(toolExpandSlots, {
-        agentRunning,
-        activeRunId,
+      pickAutoExpandedActivityIds(toolExpandSlots, {
         maxExpanded: timelineMaxAutoExpandedTools,
       }),
-    [toolExpandSlots, agentRunning, activeRunId, timelineMaxAutoExpandedTools],
+    [toolExpandSlots, timelineMaxAutoExpandedTools],
   )
   // Structure-only fingerprint: stream text must not rebuild timings / rewind targets.
   const structureEpoch = useMemo(
@@ -648,18 +686,29 @@ export function Timeline() {
         </Fragment>
       )
     }
-    return (
-      <Fragment key={item.id || blockKey}>
-        <TimelineItemBase
-          item={item}
-          prevType={prevType}
-          streaming={streamingAssistantId === item.id}
-          agentRunning={agentRunning}
-          agentBoot={agentBoot}
-          rewindEntryId={rewindEntryByItemId.get(item.id)}
-          showMessageActions={showMessageActions}
-        />
-      </Fragment>
+
+    const rowEntryId = item.sessionEntryId as string | undefined
+    const row = (
+      <TimelineItemBase
+        item={item}
+        prevType={prevType}
+        streaming={streamingAssistantId === item.id}
+        agentRunning={agentRunning}
+        agentBoot={agentBoot}
+        autoExpanded={autoExpandedToolIds.has(item.id)}
+        rewindEntryId={rewindEntryByItemId.get(item.id)}
+        showMessageActions={showMessageActions}
+      />
+    )
+    return rowEntryId ? (
+      <div key={item.id || blockKey} data-session-entry-id={rowEntryId} data-item-id={item.id}>
+        {row}
+      </div>
+    ) : (
+      <div key={item.id || blockKey} data-item-id={item.id}>
+        {row}
+      </div>
+
     )
   }
 

--- a/src/renderer/src/features/timeline/tool-call-row.tsx
+++ b/src/renderer/src/features/timeline/tool-call-row.tsx
@@ -67,8 +67,6 @@ function ToolCallRowImpl({
   autoExpandedInBudget?: boolean
 }) {
   const { t } = useTranslation()
-  const agentRunning = useUIStore((s) => s.runState.status === 'running')
-  const activeRunId = useUIStore((s) => s.runState.activeRunId)
   const expandKey = item.toolCallId || item.id
   const rememberedExpanded = useUIStore((s) => {
     if (!expandKey) return undefined
@@ -79,10 +77,10 @@ function ToolCallRowImpl({
   const setToolCallExpanded = useUIStore((s) => s.setToolCallExpanded)
   // Local fallback when store key missing or store write fails — click must always toggle.
   const [localExpanded, setLocalExpanded] = useState<boolean | null>(null)
-  const isCurrentRun = !!item.runId && item.runId === activeRunId
   const isRunning = item.toolPhase === 'start' || item.toolPhase === 'update'
   const hasToolBody = !!(item.toolOutput || item.toolDetails || item.toolArgs || item.toolDetail)
-  const autoExpanded = autoExpandedInBudget && agentRunning && isCurrentRun && hasToolBody
+  // 滑动窗口：是否由静态尾部窗口选中（不依赖 agent 运行状态，历史会话同样生效）
+  const autoExpanded = autoExpandedInBudget && hasToolBody
   const expanded =
     localExpanded ?? rememberedExpanded ?? autoExpanded
   const argSummary = toolArgSummary(item)

--- a/src/renderer/src/features/timeline/tool-group-summary.tsx
+++ b/src/renderer/src/features/timeline/tool-group-summary.tsx
@@ -132,7 +132,7 @@ function ToolGroupSummaryImpl({
                   duration={child.duration}
                   labelSeed={child.id}
                   nested
-                  autoExpanded={expanded}
+                  autoExpanded={autoExpandedToolIds?.has(child.id) ?? false}
                 />
               )
             }
@@ -152,7 +152,7 @@ function ToolGroupSummaryImpl({
                 <ToolCallRow
                   item={toolItem}
                   compact
-                  autoExpandedInBudget={expanded}
+                  autoExpandedInBudget={autoExpandedToolIds?.has(toolItem.id) ?? false}
                 />
               </div>
             )

--- a/src/renderer/src/features/timeline/tool-group-summary.tsx
+++ b/src/renderer/src/features/timeline/tool-group-summary.tsx
@@ -32,11 +32,20 @@ function ToolGroupSummaryImpl({
   foldedAssistantTexts?: string[]
 }) {
   const { t } = useTranslation()
-  const [userExpanded, setUserExpanded] = useState(false)
+  // 三态：null=未手动操作（跟随窗口预算）；true/false=用户手动展开/折叠（优先于窗口）
+  const [userExpanded, setUserExpanded] = useState<boolean | null>(null)
   const fileChanges = useUIStore((s) => s.fileChanges)
   const workspace = useUIStore((s) => s.currentWorkspace)
 
   const hasError = tools.some((tool) => tool.isError)
+
+  // 组内任一工具行命中活动窗口预算 → 组自动展开（与“最近 N 个过程行展开”语义一致）
+  const windowAutoExpanded = useMemo(
+    () => !!autoExpandedToolIds && tools.some((tool) => autoExpandedToolIds.has(tool.id)),
+    [tools, autoExpandedToolIds],
+  )
+  const expanded = userExpanded ?? windowAutoExpanded
+  const toggleExpanded = (): void => setUserExpanded((prev) => !(prev ?? windowAutoExpanded))
 
   const summary = useMemo(
     () => buildToolListActivitySummary(tools, fileChanges, workspace),
@@ -90,8 +99,8 @@ function ToolGroupSummaryImpl({
     <div className="py-0">
       <button
         type="button"
-        aria-expanded={userExpanded}
-        onClick={() => setUserExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        onClick={toggleExpanded}
         className={cn(
           'group timeline-activity-row tool-group-hit w-full',
           hasError && 'tool-group-hit--error',
@@ -99,7 +108,7 @@ function ToolGroupSummaryImpl({
       >
         <ChevronRight
           className="chevron-expand h-3 w-3 shrink-0 timeline-text-placeholder"
-          data-open={userExpanded ? 'true' : 'false'}
+          data-open={expanded ? 'true' : 'false'}
         />
         <span className="timeline-activity-label timeline-text-quiet min-w-0 truncate group-hover:opacity-70">
           {activityLabel}
@@ -110,7 +119,7 @@ function ToolGroupSummaryImpl({
           className="ml-auto pl-2"
         />
       </button>
-      {userExpanded ? (
+      {expanded ? (
         <div className="ml-3 mt-0.5 space-y-0.5 border-l border-border/12 pl-1.5">
           {orderedChildren.map((child) => {
             if (child.kind === 'thinking') {
@@ -123,6 +132,7 @@ function ToolGroupSummaryImpl({
                   duration={child.duration}
                   labelSeed={child.id}
                   nested
+                  autoExpanded={expanded}
                 />
               )
             }
@@ -142,7 +152,7 @@ function ToolGroupSummaryImpl({
                 <ToolCallRow
                   item={toolItem}
                   compact
-                  autoExpandedInBudget={!!autoExpandedToolIds?.has(toolItem.id)}
+                  autoExpandedInBudget={expanded}
                 />
               </div>
             )

--- a/src/renderer/src/lib/session-history.ts
+++ b/src/renderer/src/lib/session-history.ts
@@ -28,7 +28,8 @@ function activeWorkspace(): string | undefined {
 }
 
 function cacheKey(sessionFile: string, offset: number, limit: number) {
-  return `${sessionFile}|${offset}|${limit}`
+  const showMeta = useUIStore.getState().showNonMessageEntries ? 'meta' : 'nometa'
+  return `${showMeta}|${sessionFile}|${offset}|${limit}`
 }
 
 export async function fetchSessionHistoryTail(

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -90,8 +90,10 @@
   },
   "appearance": {
     "timeline": "Timeline",
-    "timelineToolAutoExpandMax": "Max auto-expanded tools",
-    "timelineToolAutoExpandMaxDesc": "During an active run, how many recent tool rows auto-expand details; 0 = always collapsed like Cursor (only subtle pulse). Range 0–50, default 0",
+    "timelineToolAutoExpandMax": "Activity items auto-expanded",
+    "timelineToolAutoExpandMaxDesc": "Sliding window: thinking / tool calls / command runs stay collapsed by default; only the newest N activity rows auto-expand, and the oldest collapses as new ones arrive. Manual expand/collapse always wins. 0 = window off (always collapsed). Range 0–50, default 5",
+    "showNonMessageEntries": "Show model-change entries",
+    "showNonMessageEntriesDesc": "Show non-message entries in the timeline (e.g. model switch, thinking-level change). Hidden by default. Reopen the session to apply",
     "title": "Appearance",
     "description": "Theme preview updates instantly; persist with \"Save\" at the bottom.",
     "theme": "Theme",

--- a/src/renderer/src/locales/en/timeline.json
+++ b/src/renderer/src/locales/en/timeline.json
@@ -13,6 +13,10 @@
   "expand": "Expand {{count}} lines",
   "thinkingChain": "Thinking",
   "thinkingActive": "Thinking",
+  "skillInvoked": "Skill invoked: {{name}}",
+  "skillUnknown": "unknown skill",
+  "modelChangeTo": "Switched to {{model}}",
+  "thinkingLevelChangeTo": "thinking: {{level}}",
   "thoughtDone": "Thought",
   "thinkingLines": " · {{count}}",
   "thinkingLive": {

--- a/src/renderer/src/locales/zh/settings.json
+++ b/src/renderer/src/locales/zh/settings.json
@@ -90,8 +90,10 @@
   },
   "appearance": {
     "timeline": "时间线",
-    "timelineToolAutoExpandMax": "工具自动展开上限",
-    "timelineToolAutoExpandMaxDesc": "当前对话运行中，同时自动展开详情的工具条数；0 = 始终折叠（仅淡闪烁，类似 Cursor）。范围 0–50，默认 0",
+    "timelineToolAutoExpandMax": "过程内容自动展开数量",
+    "timelineToolAutoExpandMaxDesc": "滑动窗口：时间线中思考/工具调用/命令执行等过程内容默认折叠，仅自动展开最新的 N 个，新增时最旧的自动折叠。手动展开/折叠优先于窗口。0 = 禁用窗口（始终折叠）。范围 0–50，默认 5",
+    "showNonMessageEntries": "展示模型变更记录",
+    "showNonMessageEntriesDesc": "在时间线中展示非消息条目（如模型切换、思考级别变更），默认隐藏。开启后需重新打开会话生效",
     "title": "外观",
     "description": "主题预览即时生效；持久化需点页面底部「保存」。",
     "theme": "主题",

--- a/src/renderer/src/locales/zh/timeline.json
+++ b/src/renderer/src/locales/zh/timeline.json
@@ -13,6 +13,10 @@
   "expand": "展开 {{count}} 行",
   "thinkingChain": "思考",
   "thinkingActive": "思考中",
+  "skillInvoked": "调用 skill: {{name}}",
+  "skillUnknown": "未知 skill",
+  "modelChangeTo": "切换到 {{model}}",
+  "thinkingLevelChangeTo": "thinking: {{level}}",
   "thoughtDone": "思考",
   "thinkingLines": " · {{count}}",
   "thinkingLive": {

--- a/src/renderer/src/stores/ui-store-shell-slice.ts
+++ b/src/renderer/src/stores/ui-store-shell-slice.ts
@@ -28,8 +28,13 @@ type ShellSlice = Pick<
   | 'toolExpandBySession'
   | 'setToolCallExpanded'
   | 'getToolCallExpanded'
+  | 'skillExpandBySession'
+  | 'setSkillInvocationExpanded'
+  | 'getSkillInvocationExpanded'
   | 'timelineMaxAutoExpandedTools'
   | 'setTimelineMaxAutoExpandedTools'
+  | 'showNonMessageEntries'
+  | 'setShowNonMessageEntries'
   | 'sidebarWidth'
   | 'setSidebarWidth'
   | 'sidebarCollapsed'
@@ -97,9 +102,38 @@ export function createShellSlice(set: StoreSet, get: StoreGet): ShellSlice {
         '__none__'
       return state.toolExpandBySession[sessionKey]?.[toolCallId]
     },
+    skillExpandBySession: {},
+    setSkillInvocationExpanded: (itemId, expanded) =>
+      set((state) => {
+        const sessionKey =
+          normalizeSessionFileKey(state.historySessionFile || '') ||
+          state.historySessionFile ||
+          '__none__'
+        if (!itemId) return state
+        const sessionMap = { ...(state.skillExpandBySession[sessionKey] || {}) }
+        if (expanded == null) delete sessionMap[itemId]
+        else sessionMap[itemId] = expanded
+        return {
+          skillExpandBySession: {
+            ...state.skillExpandBySession,
+            [sessionKey]: sessionMap,
+          },
+        }
+      }),
+    getSkillInvocationExpanded: (itemId) => {
+      if (!itemId) return undefined
+      const state = get()
+      const sessionKey =
+        normalizeSessionFileKey(state.historySessionFile || '') ||
+        state.historySessionFile ||
+        '__none__'
+      return state.skillExpandBySession[sessionKey]?.[itemId]
+    },
     timelineMaxAutoExpandedTools: DEFAULT_TIMELINE_MAX_AUTO_EXPANDED_TOOLS,
     setTimelineMaxAutoExpandedTools: (count) =>
       set({ timelineMaxAutoExpandedTools: normalizeTimelineMaxAutoExpandedTools(count) }),
+    showNonMessageEntries: false,
+    setShowNonMessageEntries: (v) => set({ showNonMessageEntries: v === true }),
     sidebarWidth: 260,
     setSidebarWidth: (width) => set({ sidebarWidth: Math.min(Math.max(width, 200), 360) }),
     sidebarCollapsed: false,

--- a/src/renderer/src/stores/ui-store-types.ts
+++ b/src/renderer/src/stores/ui-store-types.ts
@@ -34,7 +34,7 @@ export type ToolTimelineItem = {
 
 export interface TimelineItem {
   id: string
-  type: 'user-message' | 'assistant-message' | 'tool-call' | 'compaction' | 'error' | 'slash'
+  type: 'user-message' | 'assistant-message' | 'tool-call' | 'compaction' | 'error' | 'slash' | 'model-change'
   text?: string
   thinkingText?: string
   thinkingDuration?: number
@@ -204,8 +204,15 @@ export interface UIState {
   toolExpandBySession: Record<string, Record<string, boolean>>
   setToolCallExpanded: (toolCallId: string, expanded: boolean | null) => void
   getToolCallExpanded: (toolCallId: string) => boolean | undefined
+  /** Session-scoped skill invocation row expand memory（默认折叠，不受滑动窗口限制） */
+  skillExpandBySession: Record<string, Record<string, boolean>>
+  setSkillInvocationExpanded: (itemId: string, expanded: boolean | null) => void
+  getSkillInvocationExpanded: (itemId: string) => boolean | undefined
   timelineMaxAutoExpandedTools: number
   setTimelineMaxAutoExpandedTools: (n: number) => void
+  /** 时间线是否展示元事件条目（model_change / thinking_level_change） */
+  showNonMessageEntries: boolean
+  setShowNonMessageEntries: (v: boolean) => void
   sidebarWidth: number
   setSidebarWidth: (w: number) => void
   sidebarCollapsed: boolean

--- a/src/worker/worker-timeline.test.ts
+++ b/src/worker/worker-timeline.test.ts
@@ -160,4 +160,32 @@ describe('timelineItemsFromBranchPath non-message entries', () => {
     expect(metas[0]).toMatchObject({ model: 'acme/a' })
     expect(metas[1]).toMatchObject({ model: 'acme/b' })
   })
+
+  it('keeps every step of consecutive same-kind meta changes (A→B→C not collapsed to C)', () => {
+    const path = [
+      { id: 'm1', type: 'model_change', provider: 'acme', modelId: 'a', timestamp: '2026-08-06T00:00:00Z' },
+      { id: 'm2', type: 'model_change', provider: 'acme', modelId: 'b', timestamp: '2026-08-06T00:01:00Z' },
+      { id: 'm3', type: 'model_change', provider: 'acme', modelId: 'c', timestamp: '2026-08-06T00:02:00Z' },
+      { id: 'u', type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'hi' }] } },
+    ]
+    const metas = timelineItemsFromBranchPath(path, { showNonMessageEntries: true }).filter(
+      (i) => i.type === 'model-change',
+    )
+    expect(metas).toHaveLength(3)
+    expect(metas.map((m) => m.model)).toEqual(['acme/a', 'acme/b', 'acme/c'])
+  })
+
+  it('merges a complementary thinking change after a model change, then flushes on the next model change', () => {
+    const path = [
+      { id: 'm1', type: 'model_change', provider: 'acme', modelId: 'a', timestamp: '2026-08-06T00:00:00Z' },
+      { id: 't1', type: 'thinking_level_change', thinkingLevel: 'high', timestamp: '2026-08-06T00:01:00Z' },
+      { id: 'm2', type: 'model_change', provider: 'acme', modelId: 'b', timestamp: '2026-08-06T00:02:00Z' },
+    ]
+    const metas = timelineItemsFromBranchPath(path, { showNonMessageEntries: true }).filter(
+      (i) => i.type === 'model-change',
+    )
+    expect(metas).toHaveLength(2)
+    expect(metas[0]).toMatchObject({ model: 'acme/a', thinkingLevel: 'high' })
+    expect(metas[1]).toMatchObject({ model: 'acme/b' })
+  })
 })

--- a/src/worker/worker-timeline.test.ts
+++ b/src/worker/worker-timeline.test.ts
@@ -95,3 +95,69 @@ describe('worker timeline tool-result projection', () => {
     })
   })
 })
+
+describe('timelineItemsFromBranchPath non-message entries', () => {
+  beforeEach(() => resetTimelineSeq())
+
+  const metaEntries = [
+    {
+      id: 'model-1',
+      type: 'model_change',
+      timestamp: '2026-08-06T12:46:34.504Z',
+      provider: 'acme',
+      modelId: 'claude-fable-5',
+    },
+    {
+      id: 'think-1',
+      type: 'thinking_level_change',
+      timestamp: '2026-08-06T12:46:34.504Z',
+      thinkingLevel: 'high',
+    },
+    { id: 'user-1', type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'hi' }] } },
+  ]
+
+  it('omits meta entries by default (showNonMessageEntries=false)', () => {
+    const items = timelineItemsFromBranchPath(metaEntries)
+    expect(items.some((i) => i.type === 'model-change')).toBe(false)
+    expect(items.length).toBe(1)
+    expect(items[0].type).toBe('user-message')
+  })
+
+  it('merges adjacent model_change + thinking_level_change into one model-change entry', () => {
+    const items = timelineItemsFromBranchPath(metaEntries, { showNonMessageEntries: true })
+    const meta = items.filter((i) => i.type === 'model-change')
+    expect(meta).toHaveLength(1)
+    expect(meta[0]).toMatchObject({
+      model: 'acme/claude-fable-5',
+      thinkingLevel: 'high',
+      sessionEntryId: 'think-1',
+    })
+    expect(items.map((i) => i.type)).toEqual(['model-change', 'user-message'])
+  })
+
+  it('supports reverse order (thinking first, model second)', () => {
+    const reversed = [
+      { id: 't', type: 'thinking_level_change', thinkingLevel: 'low', timestamp: '2026-08-06T00:00:00Z' },
+      { id: 'm', type: 'model_change', provider: 'acme', modelId: 'x', timestamp: '2026-08-06T00:00:00Z' },
+      { id: 'u', type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'hi' }] } },
+    ]
+    const meta = timelineItemsFromBranchPath(reversed, { showNonMessageEntries: true }).find(
+      (i) => i.type === 'model-change',
+    )
+    expect(meta).toMatchObject({ model: 'acme/x', thinkingLevel: 'low' })
+  })
+
+  it('flushes pending meta before a following message', () => {
+    const path = [
+      { id: 'm', type: 'model_change', provider: 'acme', modelId: 'a', timestamp: '2026-08-06T00:00:00Z' },
+      { id: 'u', type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'hi' }] } },
+      { id: 'm2', type: 'model_change', provider: 'acme', modelId: 'b', timestamp: '2026-08-06T00:01:00Z' },
+    ]
+    const metas = timelineItemsFromBranchPath(path, { showNonMessageEntries: true }).filter(
+      (i) => i.type === 'model-change',
+    )
+    expect(metas).toHaveLength(2)
+    expect(metas[0]).toMatchObject({ model: 'acme/a' })
+    expect(metas[1]).toMatchObject({ model: 'acme/b' })
+  })
+})

--- a/src/worker/worker-timeline.ts
+++ b/src/worker/worker-timeline.ts
@@ -206,11 +206,20 @@ export function timelineItemsFromBranchPath(
         if (!pendingMeta) {
           pendingMeta = { sid, ts, model, thinkingLevel: e.thinkingLevel }
         } else {
-          // 合并相邻元事件：model 优先填 provider/modelId，thinking 优先填 thinkingLevel
-          if (model) pendingMeta.model = model
-          if (e.thinkingLevel) pendingMeta.thinkingLevel = e.thinkingLevel
-          if (sid) pendingMeta.sid = sid
-          pendingMeta.ts = Math.max(pendingMeta.ts, ts)
+          // 只允许“互补字段”合并（model + thinking）；同类字段已存在说明是
+          // 连续变更（如 A→B→C），必须先 flush 再开新条目，否则前一次被覆盖、
+          // 时间线静默丢失历史
+          const canMergeModel = !!model && !pendingMeta.model
+          const canMergeThinking = !!e.thinkingLevel && !pendingMeta.thinkingLevel
+          if (!canMergeModel && !canMergeThinking) {
+            flushMeta()
+            pendingMeta = { sid, ts, model, thinkingLevel: e.thinkingLevel }
+          } else {
+            if (model) pendingMeta.model = model
+            if (e.thinkingLevel) pendingMeta.thinkingLevel = e.thinkingLevel
+            if (sid) pendingMeta.sid = sid
+            pendingMeta.ts = Math.max(pendingMeta.ts, ts)
+          }
         }
         continue
       }

--- a/src/worker/worker-timeline.ts
+++ b/src/worker/worker-timeline.ts
@@ -147,11 +147,42 @@ export function normalizeMessages(messages: unknown[]): Array<Record<string, unk
   return markTrailingIncompleteAssistants(items)
 }
 
-/** 按当前 leaf 的 getBranch() 顺序建时间线，与 TUI 树上路径一致。 */
-export function timelineItemsFromBranchPath(path: unknown[]): Array<Record<string, unknown>> {
+/** 按当前 leaf 的 getBranch() 顺序建时间线，与 TUI 树上路径一致。
+ * opts.showNonMessageEntries 为 true 时，把 model_change / thinking_level_change
+ * 等元事件输出为 type:'model-change' 条目（相邻的 model+thinking 变更合并为一条）。
+ */
+export function timelineItemsFromBranchPath(
+  path: unknown[],
+  opts?: { showNonMessageEntries?: boolean },
+): Array<Record<string, unknown>> {
   const items: Array<Record<string, unknown>> = []
   const toolCallIndex = new Map<string, number>()
   const now = Date.now()
+
+  // 相邻元事件合并缓冲：model_change 与 thinking_level_change 常成对出现（任一顺序），
+  // 合并成一条「切换到 x · thinking: y」展示，避免两条噪音。
+  let pendingMeta: {
+    sid?: string
+    ts: number
+    model?: string
+    thinkingLevel?: string
+  } | null = null
+  const flushMeta = (): void => {
+    if (!pendingMeta) return
+    if (pendingMeta.model || pendingMeta.thinkingLevel) {
+      items.push({
+        id: `hist-${++msgSeq}`,
+        type: 'model-change',
+        timestamp: pendingMeta.ts,
+        ...(pendingMeta.sid ? { sessionEntryId: pendingMeta.sid } : {}),
+        ...(pendingMeta.model ? { model: pendingMeta.model } : {}),
+        ...(pendingMeta.thinkingLevel
+          ? { thinkingLevel: pendingMeta.thinkingLevel }
+          : {}),
+      })
+    }
+    pendingMeta = null
+  }
 
   for (const entry of path) {
     const e = entry as {
@@ -159,10 +190,32 @@ export function timelineItemsFromBranchPath(path: unknown[]): Array<Record<strin
       id?: string
       type?: string
       summary?: string
+      provider?: string
+      modelId?: string
+      thinkingLevel?: string
       message?: PiSessionMessage & { content?: unknown[] }
     }
     const ts = e.timestamp ? new Date(e.timestamp).getTime() : now
     const sid = e.id
+
+    if (opts?.showNonMessageEntries) {
+      if (e.type === 'model_change' || e.type === 'thinking_level_change') {
+        const provider = String(e.provider || '')
+        const modelId = String(e.modelId || '')
+        const model = provider && modelId ? `${provider}/${modelId}` : undefined
+        if (!pendingMeta) {
+          pendingMeta = { sid, ts, model, thinkingLevel: e.thinkingLevel }
+        } else {
+          // 合并相邻元事件：model 优先填 provider/modelId，thinking 优先填 thinkingLevel
+          if (model) pendingMeta.model = model
+          if (e.thinkingLevel) pendingMeta.thinkingLevel = e.thinkingLevel
+          if (sid) pendingMeta.sid = sid
+          pendingMeta.ts = Math.max(pendingMeta.ts, ts)
+        }
+        continue
+      }
+      flushMeta()
+    }
 
     if (e.type === 'compaction' && e.summary) {
       items.push({
@@ -279,6 +332,7 @@ export function timelineItemsFromBranchPath(path: unknown[]): Array<Record<strin
       }
     }
   }
+  flushMeta()
   // Force-quit mid-stream leaves empty assistant leaf — mark so UI keeps it + rewind works.
   return markTrailingIncompleteAssistants(items)
 }


### PR DESCRIPTION
## 用户场景 / 问题
长会话时间线里，用户想快速看清"这一轮 agent 干了什么"：工具调用被淹没在大量消息里；compaction/session_info 等非消息条目要么全显示（噪音）要么全隐藏（丢上下文）；skill 展开内容占屏。

## 方案
- 时间线活动窗口：按轮次聚合展示 agent 活动。
- 新增设置 `showNonMessageEntries`：控制元条目（compaction 等）是否展示。**实现细节**：该开关是 app 私有设置，主进程 `session.getMessages` 直接读 config-store，renderer 不需要逐调用透传参数（减小 IPC schema 面积）。
- skill 内容折叠展示。