### PR TITLE
fix(workspace): correct list refresh and in-place updates on session rename/delete

### DIFF
--- a/src/renderer/src/features/workspace/project-sidebar.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar.tsx
@@ -13,6 +13,7 @@ import { ProjectContextMenuPortal } from './project-context-menu'
 import { useProjectContextMenu } from './use-project-context-menu'
 import { enterBlankSession } from '@renderer/lib/blank-session-transition'
 import { refreshWorkspaceSessionLists } from '@renderer/lib/refresh-workspace-session-lists'
+import { sessionFilesEqual } from '@renderer/lib/session-file-key'
 import {
   diskProjectName,
   isSandboxPath,
@@ -77,6 +78,65 @@ export function ProjectSidebar({
       void refreshWorkspaceSessionLists()
     },
     [currentWorkspace, loadWorkspaceSessions],
+  )
+
+  /**
+   * 重命名只改标题，列表顺序不变：本地原地更新，避免整列表重拉引起的重渲染闪烁。
+   * 主进程已把新标题写入 JSONL，后续任意一次刷新都会读到一致的值。
+   */
+  const applySessionRenamed = useCallback(
+    (payload: { sessionFile: string; title: string; workspacePath: string }) => {
+      const { sessionFile, title, workspacePath } = payload
+      const applyTitle = (items: SessionItem[]) => {
+        let changed = false
+        const next = items.map((s) => {
+          if (s.sessionFile && sessionFilesEqual(s.sessionFile, sessionFile)) {
+            changed = true
+            return { ...s, title }
+          }
+          return s
+        })
+        return changed ? next : items
+      }
+      setSessionsByWorkspace((previous) => {
+        const current = previous[workspacePath]
+        if (!current) return previous
+        const next = applyTitle(current)
+        return next === current ? previous : { ...previous, [workspacePath]: next }
+      })
+      if (workspacePath === useUIStore.getState().currentWorkspace) {
+        useUIStore.setState((state) => {
+          const next = applyTitle(state.sessions)
+          return next === state.sessions ? {} : { sessions: next }
+        })
+      }
+    },
+    [],
+  )
+
+  /**
+   * 删除确认后立即从侧栏移除条目：删除 IPC 要等 worker 重建 runtime，先给用户即时反馈，
+   * 删除完成或失败后再以整列表刷新校准。
+   */
+  const applySessionRemoved = useCallback(
+    (payload: { sessionFile: string; workspacePath: string }) => {
+      const { sessionFile, workspacePath } = payload
+      const removeByFile = (items: SessionItem[]) =>
+        items.filter((s) => !(s.sessionFile && sessionFilesEqual(s.sessionFile, sessionFile)))
+      setSessionsByWorkspace((previous) => {
+        const current = previous[workspacePath]
+        if (!current) return previous
+        const next = removeByFile(current)
+        return next.length === current.length ? previous : { ...previous, [workspacePath]: next }
+      })
+      if (workspacePath === useUIStore.getState().currentWorkspace) {
+        useUIStore.setState((state) => {
+          const next = removeByFile(state.sessions)
+          return next.length === state.sessions.length ? {} : { sessions: next }
+        })
+      }
+    },
+    [],
   )
 
   const sessionMenu = useSessionContextMenu(refreshSessionsAfterMutation)
@@ -329,6 +389,8 @@ export function ProjectSidebar({
         menu={sessionMenu.menu}
         onClose={sessionMenu.close}
         onSessionsChange={refreshSessionsAfterMutation}
+        onSessionRenamed={applySessionRenamed}
+        onSessionRemoved={applySessionRemoved}
       />
       <ProjectContextMenuPortal
         menu={projectMenu.menu}

--- a/src/renderer/src/features/workspace/session-context-menu.test.tsx
+++ b/src/renderer/src/features/workspace/session-context-menu.test.tsx
@@ -52,8 +52,8 @@ describe('SessionContextMenuPortal mutations refresh the owning workspace', () =
     })
 
     expect(invokeMock).toHaveBeenCalledWith('session.delete', {
-      sessionId: 's1',
       sessionFile: '/proj/a/s1.jsonl',
+      workspaceId: '/proj/a',
     })
     expect(onSessionsChange).toHaveBeenCalledWith('/proj/a')
   })

--- a/src/renderer/src/features/workspace/session-context-menu.test.tsx
+++ b/src/renderer/src/features/workspace/session-context-menu.test.tsx
@@ -1,0 +1,83 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SessionContextMenuPortal } from './session-context-menu'
+
+const invokeMock = vi.fn(async (_method: unknown, _req?: unknown) => ({}))
+vi.mock('@renderer/lib/ipc-client', () => ({
+  ipcClient: { invoke: (method: unknown, req?: unknown) => invokeMock(method, req) },
+}))
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+vi.mock('@renderer/stores/ui-store', () => ({
+  useUIStore: {
+    getState: () => ({
+      currentSessionId: null,
+      setCurrentSession: () => {},
+      clearTimeline: () => {},
+      loadHistoryItems: () => {},
+      setHistoryMeta: () => {},
+    }),
+    setState: () => {},
+  },
+}))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+const MENU = {
+  x: 10,
+  y: 10,
+  target: {
+    sessionId: 's1',
+    sessionFile: '/proj/a/s1.jsonl',
+    title: '旧标题',
+    workspacePath: '/proj/a',
+  },
+}
+
+describe('SessionContextMenuPortal mutations refresh the owning workspace', () => {
+  afterEach(() => {
+    invokeMock.mockClear()
+  })
+
+  it('delete refreshes the owning workspace', async () => {
+    invokeMock.mockResolvedValue({ ok: true })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const onSessionsChange = vi.fn()
+    render(<SessionContextMenuPortal menu={MENU} onClose={() => {}} onSessionsChange={onSessionsChange} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common:sidebar.delete'))
+    })
+
+    expect(invokeMock).toHaveBeenCalledWith('session.delete', {
+      sessionId: 's1',
+      sessionFile: '/proj/a/s1.jsonl',
+    })
+    expect(onSessionsChange).toHaveBeenCalledWith('/proj/a')
+  })
+
+  it('rename refreshes the owning workspace', async () => {
+    invokeMock.mockResolvedValue({ ok: true })
+    const onSessionsChange = vi.fn()
+    render(<SessionContextMenuPortal menu={MENU} onClose={() => {}} onSessionsChange={onSessionsChange} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common:sidebar.rename'))
+    })
+    const input = document.querySelector('input[type="text"]') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '新标题' } })
+    await act(async () => {
+      fireEvent.click(screen.getByText('common:confirm'))
+    })
+
+    expect(invokeMock).toHaveBeenCalledWith('session.rename', {
+      sessionId: 's1',
+      sessionFile: '/proj/a/s1.jsonl',
+      title: '新标题',
+      workspaceId: '/proj/a',
+    })
+    expect(onSessionsChange).toHaveBeenCalledWith('/proj/a')
+  })
+})

--- a/src/renderer/src/features/workspace/session-context-menu.test.tsx
+++ b/src/renderer/src/features/workspace/session-context-menu.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SessionContextMenuPortal } from './session-context-menu'
 
-const invokeMock = vi.fn(async (_method: unknown, _req?: unknown) => ({}))
+const invokeMock = vi.fn(async (_method: unknown, _req?: unknown): Promise<unknown> => ({}))
 vi.mock('@renderer/lib/ipc-client', () => ({
   ipcClient: { invoke: (method: unknown, req?: unknown) => invokeMock(method, req) },
 }))
@@ -79,5 +79,67 @@ describe('SessionContextMenuPortal mutations refresh the owning workspace', () =
       workspaceId: '/proj/a',
     })
     expect(onSessionsChange).toHaveBeenCalledWith('/proj/a')
+  })
+
+  it('rename applies the title in place when onSessionRenamed is provided', async () => {
+    invokeMock.mockResolvedValue({ ok: true })
+    const onSessionsChange = vi.fn()
+    const onSessionRenamed = vi.fn()
+    render(
+      <SessionContextMenuPortal
+        menu={MENU}
+        onClose={() => {}}
+        onSessionsChange={onSessionsChange}
+        onSessionRenamed={onSessionRenamed}
+      />,
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common:sidebar.rename'))
+    })
+    const input = document.querySelector('input[type="text"]') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '新标题' } })
+    await act(async () => {
+      fireEvent.click(screen.getByText('common:confirm'))
+    })
+
+    expect(onSessionRenamed).toHaveBeenCalledWith({
+      sessionFile: '/proj/a/s1.jsonl',
+      title: '新标题',
+      workspacePath: '/proj/a',
+    })
+    // 原地更新时不再整列表重拉
+    expect(onSessionsChange).not.toHaveBeenCalled()
+  })
+
+  it('delete optimistically removes the entry before the IPC resolves', async () => {
+    let resolveDelete: (v: unknown) => void = () => {}
+    invokeMock.mockImplementation(async (method: unknown) => {
+      if (method === 'session.delete') return new Promise<unknown>((r) => (resolveDelete = r))
+      return { ok: true }
+    })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const onSessionRemoved = vi.fn()
+    render(
+      <SessionContextMenuPortal
+        menu={MENU}
+        onClose={() => {}}
+        onSessionsChange={() => {}}
+        onSessionRemoved={onSessionRemoved}
+      />,
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('common:sidebar.delete'))
+    })
+
+    // 乐观移除在 IPC 完成前就已发生
+    expect(onSessionRemoved).toHaveBeenCalledWith({
+      sessionFile: '/proj/a/s1.jsonl',
+      workspacePath: '/proj/a',
+    })
+    await act(async () => {
+      resolveDelete({ ok: true })
+    })
   })
 })

--- a/src/renderer/src/features/workspace/session-context-menu.tsx
+++ b/src/renderer/src/features/workspace/session-context-menu.tsx
@@ -25,7 +25,7 @@ export function SessionContextMenuPortal({
 }: {
   menu: MenuState
   onClose: () => void
-  onSessionsChange: () => void
+  onSessionsChange: (workspacePath?: string) => void
 }) {
   const ref = useRef<HTMLDivElement>(null)
   const { t } = useTranslation()
@@ -33,7 +33,7 @@ export function SessionContextMenuPortal({
 
   useDismissContextMenu(!!menu, ref, onClose)
 
-  const refreshList = () => onSessionsChange()
+  const refreshList = (path?: string) => onSessionsChange(path)
 
   const submitRename = async (title: string) => {
     const target = renameTarget
@@ -52,7 +52,7 @@ export function SessionContextMenuPortal({
       })
       if (r?.ok) {
         toast.success(t('common:sidebar.renamed'))
-        refreshList()
+        refreshList(target.workspacePath)
         setRenameTarget(null)
       } else toast.error(r?.error || t('common:sidebar.renameFailed'))
     } catch (e) {
@@ -86,7 +86,7 @@ export function SessionContextMenuPortal({
           void ipcClient.invoke('session.setPendingBind', { sessionFile: null })
         }
         toast.success(t('common:sidebar.deleted'))
-        refreshList()
+        refreshList(target.workspacePath)
       } else toast.error(r?.error || t('common:sidebar.deleteFailed'))
     } catch (e) {
       toast.error(t('common:sidebar.deleteFailed'))

--- a/src/renderer/src/features/workspace/session-context-menu.tsx
+++ b/src/renderer/src/features/workspace/session-context-menu.tsx
@@ -22,10 +22,16 @@ export function SessionContextMenuPortal({
   menu,
   onClose,
   onSessionsChange,
+  onSessionRenamed,
+  onSessionRemoved,
 }: {
   menu: MenuState
   onClose: () => void
   onSessionsChange: (workspacePath?: string) => void
+  /** 重命名成功后本地更新侧栏条目标题：避免整列表重拉（重命名不改变列表顺序，重拉只会引起重渲染闪烁） */
+  onSessionRenamed?: (payload: { sessionFile: string; title: string; workspacePath: string }) => void
+  /** 删除确认后立即从侧栏移除条目：删除 IPC 可能较慢（worker 重建 runtime），不让 UI 干等 */
+  onSessionRemoved?: (payload: { sessionFile: string; workspacePath: string }) => void
 }) {
   const ref = useRef<HTMLDivElement>(null)
   const { t } = useTranslation()
@@ -52,7 +58,11 @@ export function SessionContextMenuPortal({
       })
       if (r?.ok) {
         toast.success(t('common:sidebar.renamed'))
-        refreshList(target.workspacePath)
+        if (onSessionRenamed) {
+          onSessionRenamed({ sessionFile: target.sessionFile, title, workspacePath: target.workspacePath })
+        } else {
+          refreshList(target.workspacePath)
+        }
         setRenameTarget(null)
       } else toast.error(r?.error || t('common:sidebar.renameFailed'))
     } catch (e) {
@@ -71,6 +81,9 @@ export function SessionContextMenuPortal({
       onClose()
       return
     }
+    // 确认后立即乐观移除侧栏条目：删除 IPC 要等 worker 重建 runtime，不让 UI 干等；
+    // 完成或失败后再以整列表刷新校准。
+    onSessionRemoved?.({ sessionFile: target.sessionFile, workspacePath: target.workspacePath })
     try {
       const r = await ipcClient.invoke('session.delete', {
         sessionFile: target.sessionFile,
@@ -87,9 +100,14 @@ export function SessionContextMenuPortal({
         }
         toast.success(t('common:sidebar.deleted'))
         refreshList(target.workspacePath)
-      } else toast.error(r?.error || t('common:sidebar.deleteFailed'))
+      } else {
+        toast.error(r?.error || t('common:sidebar.deleteFailed'))
+        // 失败时也刷新：把乐观移除的条目恢复回来
+        refreshList(target.workspacePath)
+      }
     } catch (e) {
       toast.error(t('common:sidebar.deleteFailed'))
+      refreshList(target.workspacePath)
     }
     onClose()
   }

--- a/src/worker/handlers/worker-handlers-session.ts
+++ b/src/worker/handlers/worker-handlers-session.ts
@@ -209,8 +209,14 @@ export async function handleSessiondeletefile(msg: WorkerIncomingMessage, reply:
           const fs = await import('node:fs')
           // 先删文件：让删除动作立即生效（不阻塞在 runtime 重建上）
           if (fs.existsSync(file)) await fs.promises.unlink(file)
-          if (st.session && sessionFilePathsEqual(st.session.sessionFile, file)) {
-            await initSession(st.currentCwd)
+          // 提交点：文件已删除，删除本身已成功。之后 runtime 重建是收尾动作，
+          // 失败不得把已成功的删除报告为失败（否则 renderer 误报且标题缓存不清）
+          try {
+            if (st.session && sessionFilePathsEqual(st.session.sessionFile, file)) {
+              await initSession(st.currentCwd)
+            }
+          } catch (rebuildError: unknown) {
+            console.warn('[Worker] sessionDeleteFile: rebuild after delete failed', errorMessage(rebuildError))
           }
           reply({ type: 'sessionDeleteFile-done', ok: true })
         } catch (e: unknown) {

--- a/src/worker/handlers/worker-handlers-session.ts
+++ b/src/worker/handlers/worker-handlers-session.ts
@@ -207,10 +207,11 @@ export async function handleSessiondeletefile(msg: WorkerIncomingMessage, reply:
             return
           }
           const fs = await import('node:fs')
+          // 先删文件：让删除动作立即生效（不阻塞在 runtime 重建上）
+          if (fs.existsSync(file)) await fs.promises.unlink(file)
           if (st.session && sessionFilePathsEqual(st.session.sessionFile, file)) {
             await initSession(st.currentCwd)
           }
-          if (fs.existsSync(file)) fs.unlinkSync(file)
           reply({ type: 'sessionDeleteFile-done', ok: true })
         } catch (e: unknown) {
           reply({ type: 'sessionDeleteFile-done', ok: false, error: errorMessage(e) })


### PR DESCRIPTION
## 用户场景 / 问题
1. 在 A 项目的会话上重命名/删除，刷新的却是当前打开的 B 项目列表——A 的列表停留在旧状态。
2. 重命名后整个列表重新拉取，肉眼可见闪烁；删除要等 worker 重建 runtime 完成才从列表消失，感觉"点了没反应"。

## 代码问题
- `onSessionsChange` 回调不带 workspacePath，刷新目标错误地取了当前工作区。
- rename/delete 都走全列表重拉；删除 IPC 在 unlink 之前先做昂贵的 runtime 重建。

## 修复方案（3 个提交）
1. 会话变更回调携带 `workspacePath`，刷新归属项目的列表（带测试）。
2. rename 原位更新条目标题、delete 乐观移除条目（`onSessionRenamed`/`onSessionRemoved`），失败路径回退为刷新列表（带测试）。
3. worker 的 `sessionDeleteFile` 先异步 unlink 文件，再按需重建 runtime——删除的可见效果不再等重建。