### PR TITLE
feat(composer): surface compaction state so users can keep sending

### DIFF
--- a/src/renderer/src/app/app.tsx
+++ b/src/renderer/src/app/app.tsx
@@ -189,7 +189,11 @@ export default function App() {
     const unsubExit = onWorkerExit((info) => {
       console.warn('Worker exited:', info)
       const store = useUIStore.getState()
-      clearExitedSessionRuntime(info, store.setSessionRuntimeRunning)
+      clearExitedSessionRuntime(
+        info,
+        store.setSessionRuntimeRunning,
+        store.setCompactingSession,
+      )
     })
     return () => {
       unsubEvents()

--- a/src/renderer/src/features/composer/composer-compaction-banner.test.tsx
+++ b/src/renderer/src/features/composer/composer-compaction-banner.test.tsx
@@ -5,7 +5,7 @@ import { ComposerCompactionBanner } from './composer-compaction-banner'
 
 describe('ComposerCompactionBanner', () => {
   beforeEach(() => {
-    useUIStore.setState({ compactionActive: false })
+    useUIStore.setState({ compactingSessions: {}, historySessionFile: '/s.jsonl' })
   })
 
   it('renders nothing while no compaction is running', () => {
@@ -14,17 +14,23 @@ describe('ComposerCompactionBanner', () => {
   })
 
   it('tells the user they can keep sending while compaction runs', () => {
-    useUIStore.setState({ compactionActive: true })
+    useUIStore.setState({ compactingSessions: { '/s.jsonl': true } })
     render(<ComposerCompactionBanner />)
     expect(screen.getByText(/compacting context/i)).toBeTruthy()
   })
 
   it('disappears when compaction ends', () => {
-    useUIStore.setState({ compactionActive: true })
+    useUIStore.setState({ compactingSessions: { '/s.jsonl': true } })
     const { rerender } = render(<ComposerCompactionBanner />)
     expect(screen.getByText(/compacting context/i)).toBeTruthy()
-    useUIStore.setState({ compactionActive: false })
+    useUIStore.setState({ compactingSessions: { '/s.jsonl': false } })
     rerender(<ComposerCompactionBanner />)
+    expect(screen.queryByText(/compacting context/i)).toBeNull()
+  })
+
+  it('does not show another session compaction on the current view', () => {
+    useUIStore.setState({ compactingSessions: { '/other.jsonl': true } })
+    render(<ComposerCompactionBanner />)
     expect(screen.queryByText(/compacting context/i)).toBeNull()
   })
 })

--- a/src/renderer/src/features/composer/composer-compaction-banner.test.tsx
+++ b/src/renderer/src/features/composer/composer-compaction-banner.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useUIStore } from '@renderer/stores/ui-store'
+import { ComposerCompactionBanner } from './composer-compaction-banner'
+
+describe('ComposerCompactionBanner', () => {
+  beforeEach(() => {
+    useUIStore.setState({ compactionActive: false })
+  })
+
+  it('renders nothing while no compaction is running', () => {
+    render(<ComposerCompactionBanner />)
+    expect(screen.queryByText(/compacting context/i)).toBeNull()
+  })
+
+  it('tells the user they can keep sending while compaction runs', () => {
+    useUIStore.setState({ compactionActive: true })
+    render(<ComposerCompactionBanner />)
+    expect(screen.getByText(/compacting context/i)).toBeTruthy()
+  })
+
+  it('disappears when compaction ends', () => {
+    useUIStore.setState({ compactionActive: true })
+    const { rerender } = render(<ComposerCompactionBanner />)
+    expect(screen.getByText(/compacting context/i)).toBeTruthy()
+    useUIStore.setState({ compactionActive: false })
+    rerender(<ComposerCompactionBanner />)
+    expect(screen.queryByText(/compacting context/i)).toBeNull()
+  })
+})

--- a/src/renderer/src/features/composer/composer-compaction-banner.tsx
+++ b/src/renderer/src/features/composer/composer-compaction-banner.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'react-i18next'
+import { Sparkles } from '@renderer/components/icons'
+import { useUIStore } from '@renderer/stores/ui-store'
+
+/**
+ * Shown above the input while auto-compaction runs. The composer stays enabled
+ * during compaction — messages are queued by the agent and executed once the
+ * summary is written — so this tells the user they can keep sending instead of
+ * waiting for the compaction to finish.
+ */
+export function ComposerCompactionBanner() {
+  const { t } = useTranslation()
+  const compactionActive = useUIStore((s) => s.compactionActive)
+  if (!compactionActive) return null
+
+  return (
+    <div
+      className="mb-1.5 flex items-center gap-2 rounded-md border border-sky-500/25 bg-sky-500/8 px-2.5 py-1.5 text-[11px] leading-snug text-sky-800 dark:text-sky-200/90"
+      aria-live="polite"
+    >
+      <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-80" aria-hidden />
+      <span className="min-w-0 flex-1">{t('composer:compactionActiveHint')}</span>
+    </div>
+  )
+}

--- a/src/renderer/src/features/composer/composer-compaction-banner.tsx
+++ b/src/renderer/src/features/composer/composer-compaction-banner.tsx
@@ -1,17 +1,24 @@
 import { useTranslation } from 'react-i18next'
 import { Sparkles } from '@renderer/components/icons'
 import { useUIStore } from '@renderer/stores/ui-store'
+import { normalizeSessionFileKey } from '@renderer/lib/session-file-key'
 
 /**
- * Shown above the input while auto-compaction runs. The composer stays enabled
- * during compaction — messages are queued by the agent and executed once the
- * summary is written — so this tells the user they can keep sending instead of
- * waiting for the compaction to finish.
+ * Shown above the input while auto-compaction runs for the *current* session.
+ * Compaction state is keyed by session file, so a background session's
+ * compaction never lights the banner of the session being viewed.
+ * The composer stays enabled during compaction — messages are queued by the
+ * agent and executed once the summary is written — so this tells the user they
+ * can keep sending instead of waiting for the compaction to finish.
  */
 export function ComposerCompactionBanner() {
   const { t } = useTranslation()
-  const compactionActive = useUIStore((s) => s.compactionActive)
-  if (!compactionActive) return null
+  const historySessionFile = useUIStore((s) => s.historySessionFile)
+  const compactingSessions = useUIStore((s) => s.compactingSessions)
+  const key = historySessionFile
+    ? normalizeSessionFileKey(historySessionFile) || historySessionFile
+    : ''
+  if (!key || compactingSessions[key] !== true) return null
 
   return (
     <div

--- a/src/renderer/src/features/composer/composer.tsx
+++ b/src/renderer/src/features/composer/composer.tsx
@@ -37,6 +37,7 @@ import { makeComposerEditorAdapter } from './composer-editor-adapter'
 import { useComposerSlash } from './use-composer-slash'
 import { ComposerSlashPopover } from './composer-slash-popover'
 import { useComposerSend } from './use-composer-send'
+import { ComposerCompactionBanner } from './composer-compaction-banner'
 import { useComposerAttachments } from './use-composer-attachments'
 import { useComposerKeyDown } from './use-composer-keydown'
 import { useComposerFileSearch } from './use-composer-file-search'
@@ -381,6 +382,7 @@ export function Composer() {
         composerAnchorRef={slashPopoverAnchorRef}
         completionPopoverOpen={fileSearch.show || slash.showPopover}
       />
+      <ComposerCompactionBanner />
       <ComposerPendingQueue />
       {sessionPreview && (
         <div className="mb-2 flex items-center gap-2 rounded-lg border border-amber-500/25 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-800 dark:text-amber-200/90">

--- a/src/renderer/src/lib/__tests__/worker-exit-runtime.test.ts
+++ b/src/renderer/src/lib/__tests__/worker-exit-runtime.test.ts
@@ -2,23 +2,33 @@ import { describe, expect, it, vi } from 'vitest'
 import { clearExitedSessionRuntime } from '../worker-exit-runtime'
 
 describe('clearExitedSessionRuntime', () => {
-  it('clears the exited session running projection without touching other sessions', () => {
+  it('clears the exited session running and compaction projections', () => {
     const setSessionRuntimeRunning = vi.fn()
+    const setCompactingSession = vi.fn()
 
     clearExitedSessionRuntime(
       { code: 17, cwd: '/workspace', sessionFile: '/workspace/session.jsonl' },
       setSessionRuntimeRunning,
+      setCompactingSession,
     )
 
     expect(setSessionRuntimeRunning).toHaveBeenCalledOnce()
     expect(setSessionRuntimeRunning).toHaveBeenCalledWith('/workspace/session.jsonl', false)
+    expect(setCompactingSession).toHaveBeenCalledOnce()
+    expect(setCompactingSession).toHaveBeenCalledWith('/workspace/session.jsonl', false)
   })
 
   it('does nothing when the exited worker was not bound to a session', () => {
     const setSessionRuntimeRunning = vi.fn()
+    const setCompactingSession = vi.fn()
 
-    clearExitedSessionRuntime({ code: 0, cwd: '/workspace', sessionFile: null }, setSessionRuntimeRunning)
+    clearExitedSessionRuntime(
+      { code: 0, cwd: '/workspace', sessionFile: null },
+      setSessionRuntimeRunning,
+      setCompactingSession,
+    )
 
     expect(setSessionRuntimeRunning).not.toHaveBeenCalled()
+    expect(setCompactingSession).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/worker-exit-runtime.ts
+++ b/src/renderer/src/lib/worker-exit-runtime.ts
@@ -10,7 +10,10 @@ export type WorkerExitInfo = {
 export function clearExitedSessionRuntime(
   info: WorkerExitInfo,
   setSessionRuntimeRunning: (sessionFile: string, running: boolean) => void,
+  setCompactingSession: (sessionFile: string, active: boolean) => void,
 ): void {
   const sessionFile = normalizeSessionFileKey(info.sessionFile || '') || info.sessionFile || ''
-  if (sessionFile) setSessionRuntimeRunning(sessionFile, false)
+  if (!sessionFile) return
+  setSessionRuntimeRunning(sessionFile, false)
+  setCompactingSession(sessionFile, false)
 }

--- a/src/renderer/src/locales/en/composer.json
+++ b/src/renderer/src/locales/en/composer.json
@@ -100,6 +100,7 @@
   "queueHint": "Alt+↑ to pull back into the input · Esc while running pulls back and stops",
   "queueTitle": "{{count}} queued",
   "queueAria": "Pending queue, {{count}} items",
+  "compactionActiveHint": "Compacting context… you can keep sending; messages are queued and run after compaction finishes",
   "subagents": {
     "title": "Subagents",
     "working": "{{count}} Working",

--- a/src/renderer/src/locales/zh/composer.json
+++ b/src/renderer/src/locales/zh/composer.json
@@ -100,6 +100,7 @@
   "queueHint": "Alt+↑ 拉回输入框 · 运行中 Esc 拉回并停止",
   "queueTitle": "{{count}} 条排队",
   "queueAria": "待发送队列，共 {{count}} 条",
+  "compactionActiveHint": "正在压缩上下文… 可继续发送，消息将自动排队并在压缩完成后执行",
   "subagents": {
     "title": "Subagents",
     "working": "{{count}} 个运行中",

--- a/src/renderer/src/stores/__tests__/apply-app-event-compaction.test.ts
+++ b/src/renderer/src/stores/__tests__/apply-app-event-compaction.test.ts
@@ -24,14 +24,16 @@ vi.mock('@renderer/stores/extension-ui-store', () => ({
 
 import { handleCompaction } from '../apply-app-event-compaction'
 import { handleRun } from '../apply-app-event-run'
+import { applyBackgroundAppEvent } from '../apply-app-event-background'
+import { useUIStore } from '@renderer/stores/ui-store'
 import type { StoreApi } from '../apply-app-event-types'
 import type { CompactionEvent } from '../apply-app-event-types'
 
 function makeApi(): { api: StoreApi; state: Record<string, unknown> } {
   const state: Record<string, unknown> = {
-    compactionActive: false,
-    setCompactionActive: (active: boolean) => {
-      state.compactionActive = active
+    compactingSessions: {},
+    setCompactingSession: (sessionFile: string | null, active: boolean) => {
+      useUIStore.getState().setCompactingSession(sessionFile, active)
     },
     appendTimeline: () => undefined,
     runState: { status: 'running', activeRunId: 'run-1', startTime: Date.now() - 2000 },
@@ -59,47 +61,71 @@ function makeApi(): { api: StoreApi; state: Record<string, unknown> } {
   }
 }
 
-function compactionEvent(phase: 'start' | 'end', summary?: string): CompactionEvent {
+function compactionEvent(phase: 'start' | 'end', summary?: string, sessionFile = '/s.jsonl'): CompactionEvent {
   return {
     type: 'compaction',
     phase,
     summary,
+    sessionFile,
     timestamp: Date.now(),
   } as CompactionEvent
 }
 
-describe('handleCompaction compactionActive state', () => {
+describe('handleCompaction per-session state', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useUIStore.setState({ compactingSessions: {} })
   })
 
-  it('sets compactionActive on start and clears it on end', () => {
-    const { api, state } = makeApi()
+  it('sets the compaction flag for the event session and clears it on end', () => {
+    const { api } = makeApi()
 
     handleCompaction(compactionEvent('start'), api)
-    expect(state.compactionActive).toBe(true)
+    expect(useUIStore.getState().compactingSessions['/s.jsonl']).toBe(true)
 
     handleCompaction(compactionEvent('end', 'summary text'), api)
-    expect(state.compactionActive).toBe(false)
+    expect(useUIStore.getState().compactingSessions['/s.jsonl']).toBe(false)
   })
 
-  it('run idle clears a stale compactionActive after a lost compaction_end', () => {
-    const { api, state } = makeApi()
+  it('isolates compaction state per session', () => {
+    const { api } = makeApi()
+
+    handleCompaction(compactionEvent('start', undefined, '/a.jsonl'), api)
+    // B 从未压缩：不得显示压缩中
+    expect(useUIStore.getState().compactingSessions['/b.jsonl']).toBeUndefined()
+    // A 的 end 只清 A，不影响 B
+    handleCompaction(compactionEvent('end', undefined, '/a.jsonl'), api)
+    expect(useUIStore.getState().compactingSessions['/a.jsonl']).toBe(false)
+  })
+
+  it('background compaction events keep the session flag in sync', () => {
+    const { api } = makeApi()
+    // A 在前台开始压缩后用户切到 B：A 的 start/end 都走后台路由
+    applyBackgroundAppEvent(compactionEvent('start', undefined, '/a.jsonl'))
+    expect(useUIStore.getState().compactingSessions['/a.jsonl']).toBe(true)
+
+    applyBackgroundAppEvent(compactionEvent('end', undefined, '/a.jsonl'))
+    expect(useUIStore.getState().compactingSessions['/a.jsonl']).toBe(false)
+  })
+
+  it('run idle clears a stale compaction flag after a lost compaction_end', () => {
+    const { api } = makeApi()
 
     handleCompaction(compactionEvent('start'), api)
-    expect(state.compactionActive).toBe(true)
+    expect(useUIStore.getState().compactingSessions['/s.jsonl']).toBe(true)
 
     // Worker crashed mid-compaction: no compaction_end arrives. A later run idle
-    // (next turn / reconnect) must clear the stale badge.
+    // (next turn / reconnect) must clear the stale badge for this session.
     handleRun(
       {
         type: 'run',
         phase: 'idle',
         runId: 'run-1',
+        sessionFile: '/s.jsonl',
         timestamp: Date.now(),
       } as never,
       api,
     )
-    expect(state.compactionActive).toBe(false)
+    expect(useUIStore.getState().compactingSessions['/s.jsonl']).toBe(false)
   })
 })

--- a/src/renderer/src/stores/__tests__/apply-app-event-compaction.test.ts
+++ b/src/renderer/src/stores/__tests__/apply-app-event-compaction.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/lib/desktop-alerts', () => ({
+  signalDesktopAlert: vi.fn(),
+}))
+vi.mock('@renderer/lib/alert-trace', () => ({
+  alertTrace: vi.fn(),
+}))
+vi.mock('@renderer/lib/abort-ui-hold', () => ({
+  isAbortUiHoldActive: () => false,
+}))
+vi.mock('@renderer/lib/extension-ui-tool-sync', () => ({
+  reconcileAllStaleInteractiveToolRows: vi.fn(),
+}))
+vi.mock('@renderer/stores/ui-store-stream', () => ({
+  flushStreamPendingSync: vi.fn(),
+}))
+vi.mock('@renderer/lib/extension-ui-channel', () => ({
+  clearExtensionDialogDedupe: vi.fn(),
+}))
+vi.mock('@renderer/stores/extension-ui-store', () => ({
+  useExtensionUIStore: { getState: () => ({ clearAfterRespond: vi.fn() }) },
+}))
+
+import { handleCompaction } from '../apply-app-event-compaction'
+import { handleRun } from '../apply-app-event-run'
+import type { StoreApi } from '../apply-app-event-types'
+import type { CompactionEvent } from '../apply-app-event-types'
+
+function makeApi(): { api: StoreApi; state: Record<string, unknown> } {
+  const state: Record<string, unknown> = {
+    compactionActive: false,
+    setCompactionActive: (active: boolean) => {
+      state.compactionActive = active
+    },
+    appendTimeline: () => undefined,
+    runState: { status: 'running', activeRunId: 'run-1', startTime: Date.now() - 2000 },
+    setRunState: (patch: Record<string, unknown>) => {
+      state.runState = { ...(state.runState as Record<string, unknown>), ...patch }
+    },
+    setWorkerLiveSnapshot: (snap: unknown) => {
+      state.workerLiveSnapshot = snap
+    },
+    clearPendingQueue: () => undefined,
+    pruneEmptyAssistantBubbles: () => undefined,
+    optimisticPendingUserText: null,
+    agentTurnBootstrapping: false,
+    historySessionFile: '/s.jsonl',
+    currentSessionId: 'sid',
+    workerLiveSnapshot: { sessionId: 'sid', sessionFile: '/s.jsonl', status: 'running' },
+  }
+  return {
+    api: {
+      get: () => state as never,
+      set: (patch: unknown) => Object.assign(state, patch),
+      nextItemId: () => 'item-1',
+    } as unknown as StoreApi,
+    state,
+  }
+}
+
+function compactionEvent(phase: 'start' | 'end', summary?: string): CompactionEvent {
+  return {
+    type: 'compaction',
+    phase,
+    summary,
+    timestamp: Date.now(),
+  } as CompactionEvent
+}
+
+describe('handleCompaction compactionActive state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sets compactionActive on start and clears it on end', () => {
+    const { api, state } = makeApi()
+
+    handleCompaction(compactionEvent('start'), api)
+    expect(state.compactionActive).toBe(true)
+
+    handleCompaction(compactionEvent('end', 'summary text'), api)
+    expect(state.compactionActive).toBe(false)
+  })
+
+  it('run idle clears a stale compactionActive after a lost compaction_end', () => {
+    const { api, state } = makeApi()
+
+    handleCompaction(compactionEvent('start'), api)
+    expect(state.compactionActive).toBe(true)
+
+    // Worker crashed mid-compaction: no compaction_end arrives. A later run idle
+    // (next turn / reconnect) must clear the stale badge.
+    handleRun(
+      {
+        type: 'run',
+        phase: 'idle',
+        runId: 'run-1',
+        timestamp: Date.now(),
+      } as never,
+      api,
+    )
+    expect(state.compactionActive).toBe(false)
+  })
+})

--- a/src/renderer/src/stores/__tests__/apply-app-event-run.test.ts
+++ b/src/renderer/src/stores/__tests__/apply-app-event-run.test.ts
@@ -38,6 +38,8 @@ function makeApi(): {
     historySessionFile: '/s.jsonl',
     currentSessionId: 'sid',
     workerLiveSnapshot: { sessionId: 'sid', sessionFile: '/s.jsonl', status: 'running' },
+    compactingSessions: {},
+    setCompactingSession: vi.fn(),
     timelineItems: [
       { id: 'opt-asst-1', type: 'assistant-message', text: '', thinkingText: '', timestamp: 1 },
     ] as TimelineItem[],

--- a/src/renderer/src/stores/apply-app-event-background.ts
+++ b/src/renderer/src/stores/apply-app-event-background.ts
@@ -22,6 +22,12 @@ export function applyBackgroundAppEvent(event: AppEvent): void {
   const cacheFile = eventSessionFile(event)
   if (!cacheFile) return
 
+  // 后台会话的压缩也要同步会话级压缩状态：否则 A 的 start 转后台后
+  // end 也走这里，前台标志永远清不掉，切回 A 时错显压缩中
+  if (event.type === 'compaction') {
+    useUIStore.getState().setCompactingSession(cacheFile, event.phase === 'start')
+  }
+
   applyBackgroundAppEventToLiveTimeline(cacheFile, event)
 
   const isStreamDelta =

--- a/src/renderer/src/stores/apply-app-event-compaction.ts
+++ b/src/renderer/src/stores/apply-app-event-compaction.ts
@@ -3,6 +3,7 @@ import type { CompactionEvent, StoreApi } from '@renderer/stores/apply-app-event
 export function handleCompaction(event: CompactionEvent, api: StoreApi): void {
   const state = api.get()
   if (event.phase === 'start') {
+    state.setCompactionActive(true)
     void Promise.all([
       import('@renderer/lib/extension-ui-channel'),
       import('@renderer/stores/extension-ui-store'),
@@ -11,6 +12,7 @@ export function handleCompaction(event: CompactionEvent, api: StoreApi): void {
       st.useExtensionUIStore.getState().clearAfterRespond()
     })
   } else if (event.phase === 'end') {
+    state.setCompactionActive(false)
     state.appendTimeline({
       id: api.nextItemId(),
       type: 'compaction',

--- a/src/renderer/src/stores/apply-app-event-compaction.ts
+++ b/src/renderer/src/stores/apply-app-event-compaction.ts
@@ -2,8 +2,10 @@ import type { CompactionEvent, StoreApi } from '@renderer/stores/apply-app-event
 
 export function handleCompaction(event: CompactionEvent, api: StoreApi): void {
   const state = api.get()
+  // 压缩状态按会话键控：A 压缩中切到 B，B 不得错显；A 的 end 转后台也要能清掉
+  const sessionFile = event.sessionFile ?? null
   if (event.phase === 'start') {
-    state.setCompactionActive(true)
+    state.setCompactingSession(sessionFile, true)
     void Promise.all([
       import('@renderer/lib/extension-ui-channel'),
       import('@renderer/stores/extension-ui-store'),
@@ -12,7 +14,7 @@ export function handleCompaction(event: CompactionEvent, api: StoreApi): void {
       st.useExtensionUIStore.getState().clearAfterRespond()
     })
   } else if (event.phase === 'end') {
-    state.setCompactionActive(false)
+    state.setCompactingSession(sessionFile, false)
     state.appendTimeline({
       id: api.nextItemId(),
       type: 'compaction',

--- a/src/renderer/src/stores/apply-app-event-run.ts
+++ b/src/renderer/src/stores/apply-app-event-run.ts
@@ -4,6 +4,7 @@ import { signalDesktopAlert } from '@renderer/lib/desktop-alerts'
 import { alertTrace } from '@renderer/lib/alert-trace'
 import type { RunEvent, StoreApi } from '@renderer/stores/apply-app-event-types'
 import { flushStreamPendingSync } from '@renderer/stores/ui-store-stream'
+import { eventSessionFile } from '@renderer/stores/apply-app-event-background'
 
 /**
  * Whether a run.idle should be ignored as "too early" (race before agent_start).
@@ -100,10 +101,11 @@ export function handleRun(event: RunEvent, api: StoreApi): boolean {
       optimisticPendingUserText: null,
       agentTurnBootstrapping: false,
       streamingAssistantId: null,
-      // Compaction always finishes before the run settles; a lost compaction_end
-      // event (worker crash) must not leave the badge stuck.
-      compactionActive: false,
     })
+    // Compaction always finishes before the run settles; a lost compaction_end
+    // event (worker crash) must not leave the badge stuck. 只清本会话的压缩标志
+    const settledFile = eventSessionFile(event) || api.get().historySessionFile
+    api.get().setCompactingSession(settledFile ?? null, false)
     const rs = api.get().runState
     const wasActive = rs.status === 'running' || rs.status === 'failed'
     const prevRun = rs.activeRunId

--- a/src/renderer/src/stores/apply-app-event-run.ts
+++ b/src/renderer/src/stores/apply-app-event-run.ts
@@ -100,6 +100,9 @@ export function handleRun(event: RunEvent, api: StoreApi): boolean {
       optimisticPendingUserText: null,
       agentTurnBootstrapping: false,
       streamingAssistantId: null,
+      // Compaction always finishes before the run settles; a lost compaction_end
+      // event (worker crash) must not leave the badge stuck.
+      compactionActive: false,
     })
     const rs = api.get().runState
     const wasActive = rs.status === 'running' || rs.status === 'failed'

--- a/src/renderer/src/stores/ui-store-types.ts
+++ b/src/renderer/src/stores/ui-store-types.ts
@@ -158,6 +158,8 @@ export interface UIState {
   clearTimeline: () => void
   runState: RunState
   setRunState: (patch: Partial<RunState>) => void
+  compactionActive: boolean
+  setCompactionActive: (active: boolean) => void
   workerLiveSnapshot: WorkerLiveSnapshot
   setWorkerLiveSnapshot: (snap: WorkerLiveSnapshot) => void
   fileChanges: FileChange[]

--- a/src/renderer/src/stores/ui-store-types.ts
+++ b/src/renderer/src/stores/ui-store-types.ts
@@ -158,8 +158,9 @@ export interface UIState {
   clearTimeline: () => void
   runState: RunState
   setRunState: (patch: Partial<RunState>) => void
-  compactionActive: boolean
-  setCompactionActive: (active: boolean) => void
+  /** 压缩进行中的会话，按规范化 sessionFile 键控（A 的压缩状态不得串到 B） */
+  compactingSessions: Record<string, boolean>
+  setCompactingSession: (sessionFile: string | null, active: boolean) => void
   workerLiveSnapshot: WorkerLiveSnapshot
   setWorkerLiveSnapshot: (snap: WorkerLiveSnapshot) => void
   fileChanges: FileChange[]

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -281,6 +281,9 @@ export const useUIStore = create<UIState>()(
     return { runState: next as RunState, ...extra }
   }),
 
+  compactionActive: false,
+  setCompactionActive: (active) => set({ compactionActive: active }),
+
   fileChanges: [],
   addFileChange: (fc) => set((s) => ({ fileChanges: [...s.fileChanges.filter(f => f.path !== fc.path), fc] })),
   clearFileChanges: () => set({ fileChanges: [] }),

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -281,8 +281,12 @@ export const useUIStore = create<UIState>()(
     return { runState: next as RunState, ...extra }
   }),
 
-  compactionActive: false,
-  setCompactionActive: (active) => set({ compactionActive: active }),
+  compactingSessions: {},
+  setCompactingSession: (sessionFile, active) =>
+    set((s) => {
+      const key = sessionFile ? normalizeSessionFileKey(sessionFile) || sessionFile : ''
+      return { compactingSessions: { ...s.compactingSessions, [key]: active } }
+    }),
 
   fileChanges: [],
   addFileChange: (fc) => set((s) => ({ fileChanges: [...s.fileChanges.filter(f => f.path !== fc.path), fc] })),


### PR DESCRIPTION
## 用户场景 / 问题
上下文压缩（compaction）进行中时，UI 没有任何提示，输入框看起来像卡死；用户不知道该等还是能继续输入。

## 方案
- 从 app 事件流识别 compaction 开始/结束，`ui-store` 记录状态。
- composer 上方展示 compaction 进行中的 banner，明确告知"正在压缩上下文，可以继续输入，消息会在压缩后发送"。
- 带 store 事件处理与 banner 组件测试。