### PR TITLE
feat(app): ask before closing while a turn is running

### DIFF
--- a/packages/shared/ipc-channels.ts
+++ b/packages/shared/ipc-channels.ts
@@ -101,6 +101,8 @@ export const IPC_INVOKE_CHANNELS = [
   'ipc:slash.resolve',
   'ipc:thinkingLevel.set',
   'ipc:window:close',
+  'ipc:window:close-decision',
+  'ipc:window:close-decision-shown',
   'ipc:window:isMaximized',
   'ipc:window:maximize',
   'ipc:window:minimize',

--- a/scripts/tests/tray-main-lifecycle.test.mjs
+++ b/scripts/tests/tray-main-lifecycle.test.mjs
@@ -6,16 +6,22 @@ import { join } from 'node:path'
 const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
 
 describe('Main tray lifecycle contract', () => {
-  it('creates the tray after ready and destroys it before any graceful-shutdown early return', () => {
+  it('destroys the tray only after the quit guard allows shutdown', () => {
     const readyBlock = source.slice(source.indexOf('app.whenReady()'), source.indexOf("let isQuittingGracefully"))
     assert.match(readyBlock, /ensureAppTray\(\)/)
 
     const beforeQuit = source.match(/app\.on\(['"]before-quit['"],\s*\(event\)\s*=>\s*\{([\s\S]*?)\n\}\)/)?.[1]
     assert.ok(beforeQuit, 'before-quit handler must exist')
+    const guardPosition = beforeQuit.indexOf('if (!guardAppQuit(event)) return')
     const destroyPosition = beforeQuit.indexOf('destroyAppTray()')
     const earlyReturnPosition = beforeQuit.indexOf('if (isQuittingGracefully) return')
+    assert.ok(guardPosition >= 0, 'before-quit must preserve the close-decision guard')
     assert.ok(destroyPosition >= 0, 'before-quit must destroy the tray')
     assert.ok(earlyReturnPosition >= 0, 'before-quit must preserve graceful shutdown guard')
+    assert.ok(
+      guardPosition < destroyPosition,
+      'cancelled or pending quit decisions must leave the tray available',
+    )
     assert.ok(
       destroyPosition < earlyReturnPosition,
       'tray cleanup must run even when window-all-closed already started graceful shutdown',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -144,12 +144,11 @@ async function gracefulShutdownWorkers(): Promise<void> {
 }
 
 app.on('before-quit', (event) => {
+  // A running turn must get the close-decision prompt first (tray Quit / Cmd+Q).
+  // Keep the tray alive while the user decides so a hidden window remains reachable.
+  if (!guardAppQuit(event)) return
   destroyAppTray()
   if (isQuittingGracefully) return
-  // A running turn must get the close-decision prompt first (tray Quit / Cmd+Q).
-  // guardAppQuit prevents the event and asks the renderer; only when it returns
-  // true do we flush workers and exit.
-  if (!guardAppQuit(event)) return
   event.preventDefault()
   void gracefulShutdownWorkers().finally(() => {
     app.exit(0)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import { refreshGitWorkspaceWatch } from './git-workspace-watch'
 import { registerAllHandlers } from './ipc'
 import { workerManager } from './worker-manager'
 import { sessionPreviewProcess } from './session-preview-process'
+import { guardAppQuit } from './window-close-guard'
 import { configStore } from './config-store'
 import { is } from '@electron-toolkit/utils'
 import { destroyAppTray, ensureAppTray } from './tray'
@@ -145,6 +146,10 @@ async function gracefulShutdownWorkers(): Promise<void> {
 app.on('before-quit', (event) => {
   destroyAppTray()
   if (isQuittingGracefully) return
+  // A running turn must get the close-decision prompt first (tray Quit / Cmd+Q).
+  // guardAppQuit prevents the event and asks the renderer; only when it returns
+  // true do we flush workers and exit.
+  if (!guardAppQuit(event)) return
   event.preventDefault()
   void gracefulShutdownWorkers().finally(() => {
     app.exit(0)

--- a/src/main/ipc/handlers/window-controls.ts
+++ b/src/main/ipc/handlers/window-controls.ts
@@ -1,7 +1,15 @@
 import { registerHandler } from '../registry'
 import { getMainWindow } from '../../window'
+import { handleCloseDecision } from '../../window-close-guard'
 
 export function registerWindowControlHandlers(): void {
+  registerHandler('ipc:window:close-decision', async (req) => {
+    const action = (req as { action?: string } | null)?.action
+    if (action !== 'wait' && action !== 'now' && action !== 'cancel') {
+      return { ok: false, reason: 'invalid_action' }
+    }
+    return handleCloseDecision(action)
+  })
   registerHandler('ipc:window:minimize', async () => {
     getMainWindow()?.minimize()
     return { ok: true }

--- a/src/main/ipc/handlers/window-controls.ts
+++ b/src/main/ipc/handlers/window-controls.ts
@@ -1,6 +1,6 @@
 import { registerHandler } from '../registry'
 import { getMainWindow } from '../../window'
-import { handleCloseDecision } from '../../window-close-guard'
+import { handleCloseDecision, handleCloseDecisionShown } from '../../window-close-guard'
 
 export function registerWindowControlHandlers(): void {
   registerHandler('ipc:window:close-decision', async (req) => {
@@ -9,6 +9,11 @@ export function registerWindowControlHandlers(): void {
       return { ok: false, reason: 'invalid_action' }
     }
     return handleCloseDecision(action)
+  })
+  registerHandler('ipc:window:close-decision-shown', async () => {
+    // Renderer confirms the dialog is visible: the no-answer fallback is cleared.
+    handleCloseDecisionShown()
+    return { ok: true }
   })
   registerHandler('ipc:window:minimize', async () => {
     getMainWindow()?.minimize()

--- a/src/main/window-close-guard.test.ts
+++ b/src/main/window-close-guard.test.ts
@@ -2,10 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const workerState = vi.hoisted(() => ({ hasActiveTurns: false }))
 
+const appMock = vi.hoisted(() => ({ on: vi.fn(), quit: vi.fn() }))
+
 vi.mock('electron', () => ({
   BrowserWindow: {
     getAllWindows: () => [winMock.instance],
   },
+  app: appMock,
 }))
 
 vi.mock('./worker-manager', () => ({
@@ -26,7 +29,13 @@ const winMock = vi.hoisted(() => {
   return { instance }
 })
 
-import { installWindowCloseGuard, handleCloseDecision, __resetWindowCloseGuardForTest } from './window-close-guard'
+import {
+  installWindowCloseGuard,
+  handleCloseDecision,
+  handleCloseDecisionShown,
+  guardAppQuit,
+  __resetWindowCloseGuardForTest,
+} from './window-close-guard'
 
 type CloseEvent = { preventDefault: () => void }
 
@@ -37,6 +46,8 @@ describe('window-close-guard', () => {
   beforeEach(() => {
     __resetWindowCloseGuardForTest()
     workerState.hasActiveTurns = false
+    appMock.on.mockReset()
+    appMock.quit.mockReset()
     winMock.instance.on.mockReset()
     winMock.instance.webContents.send.mockReset()
     winMock.instance.close.mockReset()
@@ -105,6 +116,16 @@ describe('window-close-guard', () => {
     expect(winMock.instance.close).not.toHaveBeenCalled()
   })
 
+  it('wait has no fixed timeout: a long-running turn is never force-closed', () => {
+    vi.useFakeTimers()
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+    handleCloseDecision('wait')
+    vi.advanceTimersByTime(30 * 60 * 1000)
+    expect(winMock.instance.close).not.toHaveBeenCalled()
+    expect(winMock.instance.webContents.send).toHaveBeenCalledTimes(1)
+  })
+
   it('decision cancel keeps the window open and allows a fresh decision later', () => {
     workerState.hasActiveTurns = true
     closeHandler?.(makeEvent())
@@ -118,8 +139,60 @@ describe('window-close-guard', () => {
     expect(winMock.instance.close).toHaveBeenCalled()
   })
 
+  it('renderer ack of the visible dialog disarms the no-answer fallback', () => {
+    vi.useFakeTimers()
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+    handleCloseDecisionShown()
+    // Past the original ack window with the dialog visible: no force close.
+    vi.advanceTimersByTime(61 * 1000)
+    expect(winMock.instance.close).not.toHaveBeenCalled()
+  })
+
+  it('without a renderer ack the no-answer fallback unblocks the window', () => {
+    vi.useFakeTimers()
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+    vi.advanceTimersByTime(61 * 1000)
+    expect(winMock.instance.close).toHaveBeenCalled()
+  })
+
   it('invalid action is rejected', () => {
     const res = handleCloseDecision('bogus' as never)
     expect(res).toEqual({ ok: false, reason: 'invalid_action' })
+  })
+
+  describe('guardAppQuit (tray Quit / Cmd+Q)', () => {
+    it('allows quit when no turn is running', () => {
+      const e = makeEvent()
+      expect(guardAppQuit(e)).toBe(true)
+      expect(e.preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('diverts quit to the close-decision flow while a turn is running', () => {
+      workerState.hasActiveTurns = true
+      const e = makeEvent()
+      expect(guardAppQuit(e)).toBe(false)
+      expect(e.preventDefault).toHaveBeenCalled()
+      expect(winMock.instance.webContents.send).toHaveBeenCalledWith('ipc:close-requested', {
+        isStreaming: true,
+      })
+    })
+
+    it('ignores repeated quit attempts while a decision is pending', () => {
+      workerState.hasActiveTurns = true
+      guardAppQuit(makeEvent())
+      const e = makeEvent()
+      expect(guardAppQuit(e)).toBe(false)
+      expect(winMock.instance.webContents.send).toHaveBeenCalledTimes(1)
+    })
+
+    it('allows the quit after the user chose now, and re-issues app.quit', () => {
+      workerState.hasActiveTurns = true
+      guardAppQuit(makeEvent())
+      handleCloseDecision('now')
+      expect(appMock.quit).toHaveBeenCalled()
+      expect(guardAppQuit(makeEvent())).toBe(true)
+    })
   })
 })

--- a/src/main/window-close-guard.test.ts
+++ b/src/main/window-close-guard.test.ts
@@ -22,8 +22,14 @@ vi.mock('./worker-manager', () => ({
 const winMock = vi.hoisted(() => {
   const instance = {
     on: vi.fn(),
+    once: vi.fn(),
     webContents: { send: vi.fn() },
     isDestroyed: () => false,
+    isMinimized: () => false,
+    isVisible: () => true,
+    restore: vi.fn(),
+    show: vi.fn(),
+    focus: vi.fn(),
     close: vi.fn(),
   }
   return { instance }
@@ -49,7 +55,11 @@ describe('window-close-guard', () => {
     appMock.on.mockReset()
     appMock.quit.mockReset()
     winMock.instance.on.mockReset()
+    winMock.instance.once.mockReset()
     winMock.instance.webContents.send.mockReset()
+    winMock.instance.restore.mockReset()
+    winMock.instance.show.mockReset()
+    winMock.instance.focus.mockReset()
     winMock.instance.close.mockReset()
     closeHandler = null
     winMock.instance.on.mockImplementation((_evt: string, cb: (e: CloseEvent) => void) => {
@@ -162,6 +172,30 @@ describe('window-close-guard', () => {
     expect(res).toEqual({ ok: false, reason: 'invalid_action' })
   })
 
+  it('scopes force close to the closing window', () => {
+    const firstCloseHandler = closeHandler
+    firstCloseHandler?.(makeEvent())
+
+    const secondClose = vi.fn()
+    const secondOn = vi.fn((_event: string, handler: (e: CloseEvent) => void) => {
+      closeHandler = handler
+    })
+    installWindowCloseGuard({
+      ...winMock.instance,
+      on: secondOn,
+      once: vi.fn(),
+      close: secondClose,
+    } as never)
+
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+
+    expect(secondClose).not.toHaveBeenCalled()
+    expect(winMock.instance.webContents.send).toHaveBeenCalledWith('ipc:close-requested', {
+      isStreaming: true,
+    })
+  })
+
   describe('guardAppQuit (tray Quit / Cmd+Q)', () => {
     it('allows quit when no turn is running', () => {
       const e = makeEvent()
@@ -185,6 +219,20 @@ describe('window-close-guard', () => {
       const e = makeEvent()
       expect(guardAppQuit(e)).toBe(false)
       expect(winMock.instance.webContents.send).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows and focuses a hidden window before asking for a quit decision', () => {
+      workerState.hasActiveTurns = true
+      vi.spyOn(winMock.instance, 'isVisible').mockReturnValueOnce(false)
+      const e = makeEvent()
+
+      expect(guardAppQuit(e)).toBe(false)
+
+      expect(winMock.instance.show).toHaveBeenCalledOnce()
+      expect(winMock.instance.focus).toHaveBeenCalledOnce()
+      expect(winMock.instance.webContents.send).toHaveBeenCalledWith('ipc:close-requested', {
+        isStreaming: true,
+      })
     })
 
     it('allows the quit after the user chose now, and re-issues app.quit', () => {

--- a/src/main/window-close-guard.test.ts
+++ b/src/main/window-close-guard.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const workerState = vi.hoisted(() => ({ hasActiveTurns: false }))
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [winMock.instance],
+  },
+}))
+
+vi.mock('./worker-manager', () => ({
+  workerManager: {
+    get hasActiveTurns() {
+      return workerState.hasActiveTurns
+    },
+  },
+}))
+
+const winMock = vi.hoisted(() => {
+  const instance = {
+    on: vi.fn(),
+    webContents: { send: vi.fn() },
+    isDestroyed: () => false,
+    close: vi.fn(),
+  }
+  return { instance }
+})
+
+import { installWindowCloseGuard, handleCloseDecision, __resetWindowCloseGuardForTest } from './window-close-guard'
+
+type CloseEvent = { preventDefault: () => void }
+
+describe('window-close-guard', () => {
+  let closeHandler: ((e: CloseEvent) => void) | null = null
+  const makeEvent = (): CloseEvent => ({ preventDefault: vi.fn() })
+
+  beforeEach(() => {
+    __resetWindowCloseGuardForTest()
+    workerState.hasActiveTurns = false
+    winMock.instance.on.mockReset()
+    winMock.instance.webContents.send.mockReset()
+    winMock.instance.close.mockReset()
+    closeHandler = null
+    winMock.instance.on.mockImplementation((_evt: string, cb: (e: CloseEvent) => void) => {
+      closeHandler = cb
+    })
+    installWindowCloseGuard(winMock.instance as never)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('closes immediately when no turn is running', () => {
+    const e = makeEvent()
+    closeHandler?.(e)
+    expect(e.preventDefault).toHaveBeenCalled()
+    expect(winMock.instance.close).toHaveBeenCalled()
+    expect(winMock.instance.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('intercepts close and asks the renderer while a turn is running', () => {
+    workerState.hasActiveTurns = true
+    const e = makeEvent()
+    closeHandler?.(e)
+    expect(winMock.instance.close).not.toHaveBeenCalled()
+    expect(winMock.instance.webContents.send).toHaveBeenCalledWith('ipc:close-requested', {
+      isStreaming: true,
+    })
+  })
+
+  it('repeated close clicks while the dialog is open do not re-ask', () => {
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+    closeHandler?.(makeEvent())
+    expect(winMock.instance.webContents.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('decision now closes immediately', () => {
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+    const res = handleCloseDecision('now')
+    expect(res.ok).toBe(true)
+    expect(winMock.instance.close).toHaveBeenCalled()
+  })
+
+  it('decision wait closes once the turn settles', () => {
+    vi.useFakeTimers()
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+    expect(winMock.instance.close).not.toHaveBeenCalled()
+
+    handleCloseDecision('wait')
+    workerState.hasActiveTurns = false
+    vi.advanceTimersByTime(600)
+    expect(winMock.instance.close).toHaveBeenCalled()
+  })
+
+  it('decision wait does not close while the turn keeps running', () => {
+    vi.useFakeTimers()
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+    handleCloseDecision('wait')
+    vi.advanceTimersByTime(3000)
+    expect(winMock.instance.close).not.toHaveBeenCalled()
+  })
+
+  it('decision cancel keeps the window open and allows a fresh decision later', () => {
+    workerState.hasActiveTurns = true
+    closeHandler?.(makeEvent())
+    expect(winMock.instance.webContents.send).toHaveBeenCalledTimes(1)
+
+    expect(handleCloseDecision('cancel').ok).toBe(true)
+    // A later close click re-asks instead of silently closing.
+    workerState.hasActiveTurns = false
+    const e = makeEvent()
+    closeHandler?.(e)
+    expect(winMock.instance.close).toHaveBeenCalled()
+  })
+
+  it('invalid action is rejected', () => {
+    const res = handleCloseDecision('bogus' as never)
+    expect(res).toEqual({ ok: false, reason: 'invalid_action' })
+  })
+})

--- a/src/main/window-close-guard.ts
+++ b/src/main/window-close-guard.ts
@@ -1,0 +1,118 @@
+import { BrowserWindow } from 'electron'
+import { workerManager } from './worker-manager'
+
+/**
+ * Closing the window while an agent turn is running would abort the in-flight
+ * turn — its partial output is never written to the session file, so the
+ * conversation tail is lost. Instead ask the renderer for a decision:
+ *
+ * - wait: poll until the turn (including auto-compaction) settles, then close.
+ *   The finished session is fully on disk and can be continued later (CLI).
+ * - now: close immediately, aborting the running turn (status quo behaviour).
+ * - cancel: keep the window open and clear the pending decision.
+ *
+ * Tray quit / Cmd+Q go through the same window close path, so they are guarded
+ * too. `forceClose` bypasses the guard once a decision has been made.
+ */
+let forceClose = false
+let closeDecisionPending = false
+let decisionTimeout: ReturnType<typeof setTimeout> | null = null
+let waitPollTimer: ReturnType<typeof setInterval> | null = null
+
+const WAIT_POLL_MS = 500
+const WAIT_TIMEOUT_MS = 15 * 60 * 1000
+/** If the renderer never answers the close request (crash), stop blocking the window. */
+const DECISION_TIMEOUT_MS = 60 * 1000
+
+function getWindow(): BrowserWindow | null {
+  return BrowserWindow.getAllWindows()[0] ?? null
+}
+
+function stopWaitPoll(): void {
+  if (waitPollTimer) {
+    clearInterval(waitPollTimer)
+    waitPollTimer = null
+  }
+}
+
+function clearDecisionTimeout(): void {
+  if (decisionTimeout) {
+    clearTimeout(decisionTimeout)
+    decisionTimeout = null
+  }
+}
+
+function closeNow(win: BrowserWindow): void {
+  stopWaitPoll()
+  clearDecisionTimeout()
+  closeDecisionPending = false
+  forceClose = true
+  if (!win.isDestroyed()) win.close()
+}
+
+function startWaitAndClose(win: BrowserWindow): void {
+  stopWaitPoll()
+  const startedAt = Date.now()
+  waitPollTimer = setInterval(() => {
+    const timedOut = Date.now() - startedAt > WAIT_TIMEOUT_MS
+    if (!workerManager.hasActiveTurns || timedOut) {
+      closeNow(win)
+    }
+  }, WAIT_POLL_MS)
+}
+
+export function installWindowCloseGuard(win: BrowserWindow): void {
+  win.on('close', (event) => {
+    if (forceClose) return
+    event.preventDefault()
+    if (waitPollTimer) {
+      // Already waiting for the running turn — ignore further close attempts.
+      return
+    }
+    if (closeDecisionPending) {
+      // Dialog is already open; a repeated close click must not re-ask.
+      return
+    }
+    if (workerManager.hasActiveTurns) {
+      closeDecisionPending = true
+      clearDecisionTimeout()
+      decisionTimeout = setTimeout(() => {
+        closeDecisionPending = false
+        decisionTimeout = null
+        // Renderer never answered (crash / hang): fall back to closing now.
+        const winNow = getWindow()
+        if (winNow && !winNow.isDestroyed()) closeNow(winNow)
+      }, DECISION_TIMEOUT_MS)
+      win.webContents.send('ipc:close-requested', { isStreaming: true })
+      return
+    }
+    closeNow(win)
+  })
+}
+
+export function handleCloseDecision(action: 'wait' | 'now' | 'cancel'): { ok: boolean; reason?: string } {
+  const win = getWindow()
+  if (!win) return { ok: false }
+  if (action === 'wait') {
+    closeDecisionPending = false
+    clearDecisionTimeout()
+    startWaitAndClose(win)
+  } else if (action === 'now') {
+    closeNow(win)
+  } else if (action === 'cancel') {
+    closeDecisionPending = false
+    clearDecisionTimeout()
+    stopWaitPoll()
+  } else {
+    return { ok: false, reason: 'invalid_action' }
+  }
+  return { ok: true }
+}
+
+/** Test-only reset of module-level guard state. */
+export function __resetWindowCloseGuardForTest(): void {
+  forceClose = false
+  closeDecisionPending = false
+  clearDecisionTimeout()
+  stopWaitPoll()
+}

--- a/src/main/window-close-guard.ts
+++ b/src/main/window-close-guard.ts
@@ -11,14 +11,16 @@ import { workerManager } from './worker-manager'
  * - now: close immediately, aborting the running turn (status quo behaviour).
  * - cancel: keep the window open and clear the pending decision.
  *
- * Both window close and app quit (tray Quit / Cmd+Q) are guarded. `forceClose`
- * bypasses the guard once a decision has been made.
+ * Both window close and app quit (tray Quit / Cmd+Q) are guarded. Close
+ * bypasses are scoped to the window or quit attempt that the user approved.
  */
-let forceClose = false
+let forceQuit = false
+let forceCloseWindows = new WeakSet<BrowserWindow>()
 let closeDecisionPending = false
 let decisionAckTimer: ReturnType<typeof setTimeout> | null = null
 let waitPollTimer: ReturnType<typeof setInterval> | null = null
 let pendingOrigin: 'window' | 'app' | null = null
+let pendingWindow: BrowserWindow | null = null
 
 const WAIT_POLL_MS = 500
 /**
@@ -52,7 +54,13 @@ function requestCloseDecision(origin: 'window' | 'app'): boolean {
   const win = getWindow()
   if (!win || win.isDestroyed()) return false
   pendingOrigin = origin
+  pendingWindow = win
   closeDecisionPending = true
+  if (origin === 'app') {
+    if (win.isMinimized()) win.restore()
+    if (!win.isVisible()) win.show()
+    win.focus()
+  }
   clearDecisionAckTimer()
   decisionAckTimer = setTimeout(() => {
     if (!closeDecisionPending) return
@@ -60,25 +68,37 @@ function requestCloseDecision(origin: 'window' | 'app'): boolean {
     // blocking. The turn is already lost anyway — do not keep the app stuck.
     closeDecisionPending = false
     decisionAckTimer = null
-    forceClose = true
-    const winNow = getWindow()
-    if (winNow && !winNow.isDestroyed()) winNow.close()
-    if (origin === 'app') app.quit()
+    const winNow = pendingWindow ?? getWindow()
+    if (winNow && !winNow.isDestroyed()) {
+      forceCloseWindows.add(winNow)
+      winNow.close()
+    }
+    if (origin === 'app') {
+      forceQuit = true
+      app.quit()
+    }
   }, DECISION_ACK_TIMEOUT_MS)
   win.webContents.send('ipc:close-requested', { isStreaming: true })
   return true
 }
 
-function closeNow(): void {
+function closeNow(targetWindow: BrowserWindow | null = pendingWindow ?? getWindow()): void {
   stopWaitPoll()
   clearDecisionAckTimer()
   closeDecisionPending = false
-  forceClose = true
-  const win = getWindow()
-  if (win && !win.isDestroyed()) win.close()
+  const origin = pendingOrigin
+  pendingOrigin = null
+  pendingWindow = null
+  if (targetWindow && !targetWindow.isDestroyed()) {
+    forceCloseWindows.add(targetWindow)
+    targetWindow.close()
+  }
   // Tray Quit / Cmd+Q originated as app.quit(): closing the window alone leaves
   // the app running on darwin, so re-issue the quit (now passes the guard).
-  if (pendingOrigin === 'app') app.quit()
+  if (origin === 'app') {
+    forceQuit = true
+    app.quit()
+  }
 }
 
 function startWaitAndClose(): void {
@@ -95,7 +115,7 @@ function startWaitAndClose(): void {
 
 export function installWindowCloseGuard(win: BrowserWindow): void {
   win.on('close', (event) => {
-    if (forceClose) return
+    if (forceCloseWindows.has(win)) return
     event.preventDefault()
     if (waitPollTimer || closeDecisionPending) {
       // Already waiting or asking — repeated close clicks must not re-ask.
@@ -105,7 +125,7 @@ export function installWindowCloseGuard(win: BrowserWindow): void {
       requestCloseDecision('window')
       return
     }
-    closeNow()
+    closeNow(win)
   })
 }
 
@@ -115,7 +135,7 @@ export function installWindowCloseGuard(win: BrowserWindow): void {
  * false when the quit is being diverted to the close-decision flow.
  */
 export function guardAppQuit(event: { preventDefault: () => void }): boolean {
-  if (forceClose) return true
+  if (forceQuit) return true
   if (waitPollTimer || closeDecisionPending) {
     // A decision is already pending — this repeated quit attempt is ignored.
     event.preventDefault()
@@ -143,6 +163,7 @@ export function handleCloseDecision(action: 'wait' | 'now' | 'cancel'): { ok: bo
     clearDecisionAckTimer()
     stopWaitPoll()
     pendingOrigin = null
+    pendingWindow = null
   } else {
     return { ok: false, reason: 'invalid_action' }
   }
@@ -156,9 +177,11 @@ export function handleCloseDecisionShown(): void {
 
 /** Test-only reset of module-level guard state. */
 export function __resetWindowCloseGuardForTest(): void {
-  forceClose = false
+  forceQuit = false
+  forceCloseWindows = new WeakSet<BrowserWindow>()
   closeDecisionPending = false
   clearDecisionAckTimer()
   stopWaitPoll()
   pendingOrigin = null
+  pendingWindow = null
 }

--- a/src/main/window-close-guard.ts
+++ b/src/main/window-close-guard.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { workerManager } from './worker-manager'
 
 /**
@@ -11,18 +11,24 @@ import { workerManager } from './worker-manager'
  * - now: close immediately, aborting the running turn (status quo behaviour).
  * - cancel: keep the window open and clear the pending decision.
  *
- * Tray quit / Cmd+Q go through the same window close path, so they are guarded
- * too. `forceClose` bypasses the guard once a decision has been made.
+ * Both window close and app quit (tray Quit / Cmd+Q) are guarded. `forceClose`
+ * bypasses the guard once a decision has been made.
  */
 let forceClose = false
 let closeDecisionPending = false
-let decisionTimeout: ReturnType<typeof setTimeout> | null = null
+let decisionAckTimer: ReturnType<typeof setTimeout> | null = null
 let waitPollTimer: ReturnType<typeof setInterval> | null = null
+let pendingOrigin: 'window' | 'app' | null = null
 
 const WAIT_POLL_MS = 500
-const WAIT_TIMEOUT_MS = 15 * 60 * 1000
-/** If the renderer never answers the close request (crash), stop blocking the window. */
-const DECISION_TIMEOUT_MS = 60 * 1000
+/**
+ * Fallback for a renderer that never answers: if it does not confirm the
+ * decision dialog was actually displayed (crash / hang) within this window,
+ * stop blocking the app window. Once the dialog is shown, the timer is cleared
+ * and the user decides at their own pace — an unanswered prompt must never
+ * abort a running turn.
+ */
+const DECISION_ACK_TIMEOUT_MS = 60 * 1000
 
 function getWindow(): BrowserWindow | null {
   return BrowserWindow.getAllWindows()[0] ?? null
@@ -35,28 +41,54 @@ function stopWaitPoll(): void {
   }
 }
 
-function clearDecisionTimeout(): void {
-  if (decisionTimeout) {
-    clearTimeout(decisionTimeout)
-    decisionTimeout = null
+function clearDecisionAckTimer(): void {
+  if (decisionAckTimer) {
+    clearTimeout(decisionAckTimer)
+    decisionAckTimer = null
   }
 }
 
-function closeNow(win: BrowserWindow): void {
-  stopWaitPoll()
-  clearDecisionTimeout()
-  closeDecisionPending = false
-  forceClose = true
-  if (!win.isDestroyed()) win.close()
+function requestCloseDecision(origin: 'window' | 'app'): boolean {
+  const win = getWindow()
+  if (!win || win.isDestroyed()) return false
+  pendingOrigin = origin
+  closeDecisionPending = true
+  clearDecisionAckTimer()
+  decisionAckTimer = setTimeout(() => {
+    if (!closeDecisionPending) return
+    // Renderer never confirmed the dialog is visible (crash / hang): stop
+    // blocking. The turn is already lost anyway — do not keep the app stuck.
+    closeDecisionPending = false
+    decisionAckTimer = null
+    forceClose = true
+    const winNow = getWindow()
+    if (winNow && !winNow.isDestroyed()) winNow.close()
+    if (origin === 'app') app.quit()
+  }, DECISION_ACK_TIMEOUT_MS)
+  win.webContents.send('ipc:close-requested', { isStreaming: true })
+  return true
 }
 
-function startWaitAndClose(win: BrowserWindow): void {
+function closeNow(): void {
   stopWaitPoll()
-  const startedAt = Date.now()
+  clearDecisionAckTimer()
+  closeDecisionPending = false
+  forceClose = true
+  const win = getWindow()
+  if (win && !win.isDestroyed()) win.close()
+  // Tray Quit / Cmd+Q originated as app.quit(): closing the window alone leaves
+  // the app running on darwin, so re-issue the quit (now passes the guard).
+  if (pendingOrigin === 'app') app.quit()
+}
+
+function startWaitAndClose(): void {
+  stopWaitPoll()
+  // No fixed timeout: the user explicitly chose to wait, so the window closes
+  // only once the turn (including compaction) settles. If it never settles,
+  // the dialog's "Cancel waiting" remains the escape hatch.
   waitPollTimer = setInterval(() => {
-    const timedOut = Date.now() - startedAt > WAIT_TIMEOUT_MS
-    if (!workerManager.hasActiveTurns || timedOut) {
-      closeNow(win)
+    if (!workerManager.hasActiveTurns) {
+      closeNow()
     }
   }, WAIT_POLL_MS)
 }
@@ -65,29 +97,36 @@ export function installWindowCloseGuard(win: BrowserWindow): void {
   win.on('close', (event) => {
     if (forceClose) return
     event.preventDefault()
-    if (waitPollTimer) {
-      // Already waiting for the running turn — ignore further close attempts.
-      return
-    }
-    if (closeDecisionPending) {
-      // Dialog is already open; a repeated close click must not re-ask.
+    if (waitPollTimer || closeDecisionPending) {
+      // Already waiting or asking — repeated close clicks must not re-ask.
       return
     }
     if (workerManager.hasActiveTurns) {
-      closeDecisionPending = true
-      clearDecisionTimeout()
-      decisionTimeout = setTimeout(() => {
-        closeDecisionPending = false
-        decisionTimeout = null
-        // Renderer never answered (crash / hang): fall back to closing now.
-        const winNow = getWindow()
-        if (winNow && !winNow.isDestroyed()) closeNow(winNow)
-      }, DECISION_TIMEOUT_MS)
-      win.webContents.send('ipc:close-requested', { isStreaming: true })
+      requestCloseDecision('window')
       return
     }
-    closeNow(win)
+    closeNow()
   })
+}
+
+/**
+ * Guard for app.quit() paths (tray Quit, Cmd+Q, window menu). Returns true when
+ * the quit should proceed normally (no running turn, or a decision was made);
+ * false when the quit is being diverted to the close-decision flow.
+ */
+export function guardAppQuit(event: { preventDefault: () => void }): boolean {
+  if (forceClose) return true
+  if (waitPollTimer || closeDecisionPending) {
+    // A decision is already pending — this repeated quit attempt is ignored.
+    event.preventDefault()
+    return false
+  }
+  if (workerManager.hasActiveTurns) {
+    event.preventDefault()
+    requestCloseDecision('app')
+    return false
+  }
+  return true
 }
 
 export function handleCloseDecision(action: 'wait' | 'now' | 'cancel'): { ok: boolean; reason?: string } {
@@ -95,24 +134,31 @@ export function handleCloseDecision(action: 'wait' | 'now' | 'cancel'): { ok: bo
   if (!win) return { ok: false }
   if (action === 'wait') {
     closeDecisionPending = false
-    clearDecisionTimeout()
-    startWaitAndClose(win)
+    clearDecisionAckTimer()
+    startWaitAndClose()
   } else if (action === 'now') {
-    closeNow(win)
+    closeNow()
   } else if (action === 'cancel') {
     closeDecisionPending = false
-    clearDecisionTimeout()
+    clearDecisionAckTimer()
     stopWaitPoll()
+    pendingOrigin = null
   } else {
     return { ok: false, reason: 'invalid_action' }
   }
   return { ok: true }
 }
 
+/** Renderer confirms the decision dialog is visible — the ack fallback no longer applies. */
+export function handleCloseDecisionShown(): void {
+  if (closeDecisionPending) clearDecisionAckTimer()
+}
+
 /** Test-only reset of module-level guard state. */
 export function __resetWindowCloseGuardForTest(): void {
   forceClose = false
   closeDecisionPending = false
-  clearDecisionTimeout()
+  clearDecisionAckTimer()
   stopWaitPoll()
+  pendingOrigin = null
 }

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -10,6 +10,7 @@ const useFrameless = isWin || isMac || isLinux
 import { configStore } from './config-store'
 import { customThemeRendererArgument } from './custom-theme-startup'
 import { workerManager } from './worker-manager'
+import { installWindowCloseGuard } from './window-close-guard'
 
 const MIN_W = 900
 const MIN_H = 600
@@ -97,6 +98,8 @@ export function createWindow(): BrowserWindow {
       nodeIntegration: false,
     },
   })
+
+  installWindowCloseGuard(mainWindow)
 
   mainWindow.on('ready-to-show', () => {
     if (isE2eTestMode()) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -87,6 +87,11 @@ const api = {
     return () => ipcRenderer.off('ipc:git-workspace-changed', handler)
   },
 
+  onCloseRequested(callback: (info: { isStreaming: boolean }) => void): () => void {
+    const handler = (_event: unknown, data: { isStreaming: boolean }): void => callback(data)
+    ipcRenderer.on('ipc:close-requested', handler)
+    return () => ipcRenderer.off('ipc:close-requested', handler)
+  },
   ping: (): string => 'pong',
 }
 

--- a/src/renderer/src/app/app.tsx
+++ b/src/renderer/src/app/app.tsx
@@ -38,6 +38,7 @@ import {
 import { CommandPalette, ShortcutsHelpSheet } from '@renderer/features/shell/command-palette'
 import { EmptyState } from '@renderer/components/ui/empty-state'
 import { AppUpdateHost } from '@renderer/lib/app-update-notify'
+import { CloseDecisionDialog } from '@renderer/components/ui/close-decision-dialog'
 import { clearExitedSessionRuntime } from '@renderer/lib/worker-exit-runtime'
 import {
   invalidateAvailableModels,
@@ -282,6 +283,7 @@ export default function App() {
         </div>
         {paletteAndShortcuts}
         <AppUpdateHost />
+        <CloseDecisionDialog />
       </ErrorBoundary>
     )
   }
@@ -362,6 +364,7 @@ export default function App() {
       <AppToaster />
       <ExtensionUIHost />
       <AppUpdateHost />
+      <CloseDecisionDialog />
       {paletteAndShortcuts}
       <Suspense fallback={null}>
         {modelPickerOpen && <ModelPicker />}

--- a/src/renderer/src/components/ui/close-decision-dialog.test.tsx
+++ b/src/renderer/src/components/ui/close-decision-dialog.test.tsx
@@ -1,0 +1,78 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import '@renderer/lib/i18n'
+import { CloseDecisionDialog } from './close-decision-dialog'
+
+const mocks = vi.hoisted(() => ({
+  onCloseRequested: vi.fn(),
+  invoke: vi.fn(),
+}))
+
+vi.mock('@renderer/lib/ipc-client', () => ({
+  onCloseRequested: mocks.onCloseRequested,
+  ipcClient: { invoke: mocks.invoke },
+}))
+
+describe('CloseDecisionDialog', () => {
+  beforeEach(() => {
+    mocks.onCloseRequested.mockReset()
+    mocks.invoke.mockReset()
+    mocks.invoke.mockResolvedValue({ ok: true })
+    mocks.onCloseRequested.mockImplementation((cb: (info: { isStreaming: boolean }) => void) => {
+      ;(mocks.onCloseRequested as unknown as { cb?: (info: { isStreaming: boolean }) => void }).cb = cb
+      return () => undefined
+    })
+  })
+
+  function emitCloseRequested() {
+    const cb = (mocks.onCloseRequested as unknown as { cb?: (info: { isStreaming: boolean }) => void }).cb
+    act(() => {
+      cb?.({ isStreaming: true })
+    })
+  }
+
+  it('renders nothing until the main process asks', () => {
+    render(<CloseDecisionDialog />)
+    expect(screen.queryByText(/A conversation is still running/i)).toBeNull()
+  })
+
+  it('shows the two options and cancel when close is requested while running', () => {
+    render(<CloseDecisionDialog />)
+    emitCloseRequested()
+    expect(screen.getByText('Wait for it to finish, then close')).toBeTruthy()
+    expect(screen.getByText('Close now')).toBeTruthy()
+    expect(screen.getByText('Cancel')).toBeTruthy()
+  })
+
+  it('wait decision invokes close-decision with action wait and shows waiting state', () => {
+    render(<CloseDecisionDialog />)
+    emitCloseRequested()
+    fireEvent.click(screen.getByText('Wait for it to finish, then close'))
+    expect(mocks.invoke).toHaveBeenCalledWith('window.close-decision', { action: 'wait' })
+    expect(screen.getByText('Waiting for the conversation to finish…')).toBeTruthy()
+  })
+
+  it('close now invokes close-decision with action now and dismisses', () => {
+    render(<CloseDecisionDialog />)
+    emitCloseRequested()
+    fireEvent.click(screen.getByText('Close now'))
+    expect(mocks.invoke).toHaveBeenCalledWith('window.close-decision', { action: 'now' })
+    expect(screen.queryByText(/A conversation is still running/i)).toBeNull()
+  })
+
+  it('cancel invokes close-decision with action cancel and dismisses', () => {
+    render(<CloseDecisionDialog />)
+    emitCloseRequested()
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(mocks.invoke).toHaveBeenCalledWith('window.close-decision', { action: 'cancel' })
+    expect(screen.queryByText(/A conversation is still running/i)).toBeNull()
+  })
+
+  it('cancel waiting sends action cancel back', () => {
+    render(<CloseDecisionDialog />)
+    emitCloseRequested()
+    fireEvent.click(screen.getByText('Wait for it to finish, then close'))
+    fireEvent.click(screen.getByText('Cancel waiting'))
+    expect(mocks.invoke).toHaveBeenLastCalledWith('window.close-decision', { action: 'cancel' })
+  })
+})

--- a/src/renderer/src/components/ui/close-decision-dialog.test.tsx
+++ b/src/renderer/src/components/ui/close-decision-dialog.test.tsx
@@ -48,7 +48,7 @@ describe('CloseDecisionDialog', () => {
     render(<CloseDecisionDialog />)
     emitCloseRequested()
     fireEvent.click(screen.getByText('Wait for it to finish, then close'))
-    expect(mocks.invoke).toHaveBeenCalledWith('window.close-decision', { action: 'wait' })
+    expect(mocks.invoke).toHaveBeenCalledWith('window:close-decision', { action: 'wait' })
     expect(screen.getByText('Waiting for the conversation to finish…')).toBeTruthy()
   })
 
@@ -56,7 +56,7 @@ describe('CloseDecisionDialog', () => {
     render(<CloseDecisionDialog />)
     emitCloseRequested()
     fireEvent.click(screen.getByText('Close now'))
-    expect(mocks.invoke).toHaveBeenCalledWith('window.close-decision', { action: 'now' })
+    expect(mocks.invoke).toHaveBeenCalledWith('window:close-decision', { action: 'now' })
     expect(screen.queryByText(/A conversation is still running/i)).toBeNull()
   })
 
@@ -64,7 +64,7 @@ describe('CloseDecisionDialog', () => {
     render(<CloseDecisionDialog />)
     emitCloseRequested()
     fireEvent.click(screen.getByText('Cancel'))
-    expect(mocks.invoke).toHaveBeenCalledWith('window.close-decision', { action: 'cancel' })
+    expect(mocks.invoke).toHaveBeenCalledWith('window:close-decision', { action: 'cancel' })
     expect(screen.queryByText(/A conversation is still running/i)).toBeNull()
   })
 
@@ -73,6 +73,6 @@ describe('CloseDecisionDialog', () => {
     emitCloseRequested()
     fireEvent.click(screen.getByText('Wait for it to finish, then close'))
     fireEvent.click(screen.getByText('Cancel waiting'))
-    expect(mocks.invoke).toHaveBeenLastCalledWith('window.close-decision', { action: 'cancel' })
+    expect(mocks.invoke).toHaveBeenLastCalledWith('window:close-decision', { action: 'cancel' })
   })
 })

--- a/src/renderer/src/components/ui/close-decision-dialog.tsx
+++ b/src/renderer/src/components/ui/close-decision-dialog.tsx
@@ -26,8 +26,15 @@ export function CloseDecisionDialog() {
     })
   }, [])
 
+  // Tell main the dialog is actually visible so its no-answer fallback is
+  // cleared — an unanswered prompt must never abort the running turn.
+  useEffect(() => {
+    if (!open) return
+    void ipcClient.invoke('window:close-decision-shown').catch(() => {})
+  }, [open])
+
   const decide = (action: CloseAction) => {
-    void ipcClient.invoke('window.close-decision', { action })
+    void ipcClient.invoke('window:close-decision', { action })
     if (action === 'wait') {
       setWaiting(true)
     } else {

--- a/src/renderer/src/components/ui/close-decision-dialog.tsx
+++ b/src/renderer/src/components/ui/close-decision-dialog.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useId, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { ipcClient, onCloseRequested } from '@renderer/lib/ipc-client'
+
+type CloseAction = 'wait' | 'now' | 'cancel'
+
+/**
+ * Shown when the user closes the window while an agent turn is running.
+ * The main process intercepts the close and asks for a decision:
+ * - wait: close after the running turn (incl. auto-compaction) settles, so the
+ *   session tail is saved and can be continued later (e.g. with the pi CLI).
+ * - now: close immediately (aborts the in-flight turn).
+ * - cancel: keep the window open.
+ */
+export function CloseDecisionDialog() {
+  const { t } = useTranslation()
+  const titleId = useId()
+  const [open, setOpen] = useState(false)
+  const [waiting, setWaiting] = useState(false)
+
+  useEffect(() => {
+    return onCloseRequested(() => {
+      setWaiting(false)
+      setOpen(true)
+    })
+  }, [])
+
+  const decide = (action: CloseAction) => {
+    void ipcClient.invoke('window.close-decision', { action })
+    if (action === 'wait') {
+      setWaiting(true)
+    } else {
+      setOpen(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') decide('cancel')
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, waiting])
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="electron-no-drag fixed inset-0 z-[600] flex items-center justify-center bg-black/40 p-4"
+      role="presentation"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) decide('cancel')
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-md rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-xl"
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        {waiting ? (
+          <>
+            <h2 id={titleId} className="mb-2 text-lg font-semibold text-foreground">
+              {t('common:window.waitingTitle')}
+            </h2>
+            <p className="mb-4 text-base leading-relaxed text-muted-foreground">
+              {t('common:window.waitingMessage')}
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                className="rounded-md border border-border px-3 py-1.5 text-sm text-foreground hover:bg-muted"
+                onClick={() => decide('cancel')}
+              >
+                {t('common:window.cancelWait')}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 id={titleId} className="mb-2 text-lg font-semibold text-foreground">
+              {t('common:window.closeWhileRunningTitle')}
+            </h2>
+            <p className="mb-4 text-base leading-relaxed text-muted-foreground">
+              {t('common:window.closeWhileRunningMessage')}
+            </p>
+            <div className="flex flex-col gap-2">
+              <button
+                className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                onClick={() => decide('wait')}
+              >
+                {t('common:window.waitThenClose')}
+              </button>
+              <div className="flex justify-end gap-2">
+                <button
+                  className="rounded-md border border-border px-3 py-1.5 text-sm text-foreground hover:bg-muted"
+                  onClick={() => decide('cancel')}
+                >
+                  {t('common:cancel')}
+                </button>
+                <button
+                  className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
+                  onClick={() => decide('now')}
+                >
+                  {t('common:window.closeNow')}
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -18,6 +18,7 @@ declare global {
       onAppUpdateAvailable: (callback: (info: AppUpdateAvailableInfo) => void) => () => void
       onAppUpdateDownloadProgress?: (callback: (info: AppUpdateDownloadProgress) => void) => () => void
       onGitWorkspaceChanged: (callback: (payload: { cwd: string }) => void) => () => void
+      onCloseRequested?: (callback: (info: { isStreaming: boolean }) => void) => () => void
       ping: () => string
     }
   }
@@ -81,4 +82,11 @@ export function onAppUpdateDownloadProgress(
 export function onGitWorkspaceChanged(callback: (payload: { cwd: string }) => void): () => void {
   if (!window.piDesktop) return () => {}
   return window.piDesktop.onGitWorkspaceChanged(callback)
+}
+
+export function onCloseRequested(
+  callback: (info: { isStreaming: boolean }) => void,
+): () => void {
+  if (!window.piDesktop?.onCloseRequested) return () => {}
+  return window.piDesktop.onCloseRequested(callback)
 }

--- a/src/renderer/src/locales/en/common.json
+++ b/src/renderer/src/locales/en/common.json
@@ -141,7 +141,14 @@
     "minimize": "Minimize",
     "maximize": "Maximize",
     "restore": "Restore",
-    "close": "Close"
+    "close": "Close",
+    "closeWhileRunningTitle": "A conversation is still running",
+    "closeWhileRunningMessage": "Closing now would interrupt the running conversation and lose its tail. You can wait for it to finish so the session is saved completely and can be continued later (e.g. with the pi CLI).",
+    "waitThenClose": "Wait for it to finish, then close",
+    "closeNow": "Close now",
+    "waitingTitle": "Waiting for the conversation to finish…",
+    "waitingMessage": "The window will close automatically once the conversation (including context compaction) completes.",
+    "cancelWait": "Cancel waiting"
   },
   "sessionReload": {
     "success": "Session data refreshed",

--- a/src/renderer/src/locales/zh/common.json
+++ b/src/renderer/src/locales/zh/common.json
@@ -141,7 +141,14 @@
     "minimize": "最小化",
     "maximize": "最大化",
     "restore": "还原",
-    "close": "关闭"
+    "close": "关闭",
+    "closeWhileRunningTitle": "当前有对话正在进行",
+    "closeWhileRunningMessage": "关闭窗口会中断正在进行的对话，其尾部内容不会保存。可以选择等待对话完成后再关闭，这样会话会完整保存，之后可以继续（如用 pi 命令行）。",
+    "waitThenClose": "等待完成后再关闭",
+    "closeNow": "立即关闭",
+    "waitingTitle": "正在等待对话结束…",
+    "waitingMessage": "对话（含上下文压缩）完成后窗口将自动关闭。",
+    "cancelWait": "取消等待"
   },
   "sessionReload": {
     "success": "已刷新会话数据",


### PR DESCRIPTION
## 用户场景 / 问题
对话还在流式输出时直接关窗口，运行中的 turn 被硬杀：会话尾部丢失，JSONL 停在半截，之后 CLI 继续该会话时上下文不完整。

## 方案
- 主进程 `window-close-guard`：关窗时若有 turn 在跑，拦截 close 并通知 renderer（`ipc:close-requested`）。
- renderer 弹出决策对话框：**等它跑完再关**（等待态，含 compaction 完成后自动关窗，可取消等待）或 **立即关闭**。
- 空闲时关窗行为完全不变。主进程 guard 与对话框组件均带测试（14 个用例）。