### PR TITLE
fix(rewind): refresh session tree on open and drop stale loads

### DIFF
--- a/src/renderer/src/features/rewind/tree-panel.test.tsx
+++ b/src/renderer/src/features/rewind/tree-panel.test.tsx
@@ -1,0 +1,39 @@
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TreePanel } from './tree-panel'
+import { useUIStore } from '@renderer/stores/ui-store'
+import { refreshSessionTree } from '@renderer/lib/rewind-metadata'
+
+vi.mock('@renderer/lib/session-rewind', () => ({ navigateSessionToEntry: vi.fn(async () => true) }))
+vi.mock('@renderer/lib/session-fork', () => ({ forkSessionFromEntry: vi.fn(async () => true) }))
+vi.mock('@renderer/lib/rewind-metadata', () => ({ refreshSessionTree: vi.fn(async () => {}) }))
+vi.mock('@renderer/lib/ipc-client', () => ({ ipcClient: { invoke: vi.fn(async () => ({})) } }))
+
+const nodes = [
+  { id: 'u1', depth: 0, entryType: 'message', role: 'user', preview: '第一条用户消息', isLeaf: false },
+  { id: 'a1', depth: 1, entryType: 'message', role: 'assistant', preview: '第一条回复', isLeaf: true },
+]
+
+beforeEach(() => {
+  vi.mocked(refreshSessionTree).mockClear()
+  useUIStore.setState({
+    currentWorkspace: '/tmp/proj',
+    historySessionFile: '/tmp/proj/session.jsonl',
+    rewindTreeNodes: nodes as never,
+    rewindLoadingTree: false,
+    rewindTreeError: undefined,
+  })
+})
+
+describe('TreePanel refresh behaviour', () => {
+  it('refreshes the tree on mount and when the session file changes', () => {
+    const refresh = vi.mocked(refreshSessionTree)
+    render(<TreePanel />)
+    // 树数据是发送时点的快照：即使非空也要在挂载时刷新，
+    // 否则「新消息已写入 JSONL 但树未更新」的情况会一直显示旧数据
+    expect(refresh).toHaveBeenCalledWith('/tmp/proj/session.jsonl')
+
+    act(() => useUIStore.setState({ historySessionFile: '/other/session.jsonl' }))
+    expect(refresh).toHaveBeenLastCalledWith('/other/session.jsonl')
+  })
+})

--- a/src/renderer/src/features/rewind/tree-panel.tsx
+++ b/src/renderer/src/features/rewind/tree-panel.tsx
@@ -38,9 +38,11 @@ export function TreePanel() {
   }, [sessionFile])
 
   useEffect(() => {
-    // 挂载 / 切换会话时刷新：树数据是发送时点刷新后的快照，仅凭空树判断会
-    // 漏掉“新消息已写入 JSONL 但树未更新”的情况（例如压缩排队期间发送）。
-    if (sessionFile) void refreshSessionTree(sessionFile)
+    // 挂载 / 切换会话（含切到无会话）时刷新：树数据是发送时点刷新后的快照，
+    // 仅凭空树判断会漏掉“新消息已写入 JSONL 但树未更新”的情况（例如压缩排队期间发送）。
+    // sessionFile 变 null 也必须刷新：让请求序号递增，使 A 的在途旧请求失效，
+    // 否则旧树的响应会在空会话 store 里回填。
+    void refreshSessionTree(sessionFile)
   }, [sessionFile])
 
   const filtered = useMemo(() => filterSessionTreeNodes(rawTree, filter), [rawTree, filter])

--- a/src/renderer/src/features/rewind/tree-panel.tsx
+++ b/src/renderer/src/features/rewind/tree-panel.tsx
@@ -38,10 +38,10 @@ export function TreePanel() {
   }, [sessionFile])
 
   useEffect(() => {
-    if (sessionFile && rawTree.length === 0 && !loading && !treeError) {
-      void refreshSessionTree(sessionFile)
-    }
-  }, [sessionFile, rawTree.length, loading, treeError])
+    // 挂载 / 切换会话时刷新：树数据是发送时点刷新后的快照，仅凭空树判断会
+    // 漏掉“新消息已写入 JSONL 但树未更新”的情况（例如压缩排队期间发送）。
+    if (sessionFile) void refreshSessionTree(sessionFile)
+  }, [sessionFile])
 
   const filtered = useMemo(() => filterSessionTreeNodes(rawTree, filter), [rawTree, filter])
   const { nodes: display, truncated, hiddenCount } = useMemo(

--- a/src/renderer/src/lib/__tests__/rewind-metadata.test.ts
+++ b/src/renderer/src/lib/__tests__/rewind-metadata.test.ts
@@ -79,4 +79,17 @@ describe('refreshSessionTree concurrency guard', () => {
     ])
     expect(useUIStore.getState().rewindKey).toBe('/b.jsonl')
   })
+
+  it('switching to no session invalidates an in-flight refresh and clears the store', async () => {
+    const p1 = refreshSessionTree('/a.jsonl')
+    // 切到无会话：序号递增，A 的在途响应必须失效并清空树
+    refreshSessionTree(null)
+    expect(useUIStore.getState().rewindTreeNodes).toEqual([])
+    expect(useUIStore.getState().rewindKey).toBe('')
+
+    pending[0].resolve({ nodes: [{ id: 'a1', entryType: 'message', isLeaf: true }] })
+    await p1
+    expect(useUIStore.getState().rewindTreeNodes).toEqual([])
+    expect(useUIStore.getState().rewindKey).toBe('')
+  })
 })

--- a/src/renderer/src/lib/__tests__/rewind-metadata.test.ts
+++ b/src/renderer/src/lib/__tests__/rewind-metadata.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { refreshSessionTree } from '../rewind-metadata'
+import { useUIStore } from '@renderer/stores/ui-store'
+
+type Deferred = { resolve: (v: unknown) => void; reject: (e: unknown) => void }
+const pending: Deferred[] = []
+
+vi.mock('@renderer/lib/ipc-client', () => ({
+  ipcClient: {
+    invoke: vi.fn(
+      () =>
+        new Promise((resolve, reject) =>
+          pending.push({ resolve, reject: reject as (e: unknown) => void }),
+        ),
+    ),
+  },
+}))
+
+describe('refreshSessionTree concurrency guard', () => {
+  beforeEach(() => {
+    pending.length = 0
+    useUIStore.setState({
+      rewindKey: '',
+      rewindLoadingTree: false,
+      rewindTreeError: undefined,
+    })
+    useUIStore.getState().setRewindMeta({ treeNodes: [], workerBound: false })
+  })
+
+  it('a stale response does not overwrite a newer tree for the same session', async () => {
+    const p1 = refreshSessionTree('/s.jsonl')
+    const p2 = refreshSessionTree('/s.jsonl')
+    expect(pending.length).toBe(2)
+
+    // The later request resolves first with the newest file snapshot.
+    pending[1].resolve({ nodes: [{ id: 'n2', entryType: 'message', role: 'user', isLeaf: true }] })
+    await p2
+    expect(useUIStore.getState().rewindTreeNodes).toEqual([
+      { id: 'n2', entryType: 'message', role: 'user', isLeaf: true },
+    ])
+
+    // The earlier request resolves afterwards with a stale snapshot: must be dropped.
+    pending[0].resolve({ nodes: [{ id: 'n1', entryType: 'message', role: 'user', isLeaf: true }] })
+    await p1
+    expect(useUIStore.getState().rewindTreeNodes).toEqual([
+      { id: 'n2', entryType: 'message', role: 'user', isLeaf: true },
+    ])
+    expect(useUIStore.getState().rewindLoadingTree).toBe(false)
+  })
+
+  it('an error from a stale request does not clear the current tree', async () => {
+    const p1 = refreshSessionTree('/s.jsonl')
+    const p2 = refreshSessionTree('/s.jsonl')
+
+    pending[1].resolve({ nodes: [{ id: 'n2', entryType: 'message', isLeaf: false }] })
+    await p2
+
+    pending[0].reject(new Error('stale read failed'))
+    await p1.catch(() => {})
+    expect(useUIStore.getState().rewindTreeNodes).toEqual([
+      { id: 'n2', entryType: 'message', isLeaf: false },
+    ])
+    expect(useUIStore.getState().rewindTreeError).toBeUndefined()
+  })
+
+  it('switching to another session invalidates an in-flight refresh', async () => {
+    const p1 = refreshSessionTree('/a.jsonl')
+    refreshSessionTree('/b.jsonl')
+
+    pending[1].resolve({ nodes: [{ id: 'b1', entryType: 'message', isLeaf: true }] })
+    // wait for the second request to settle
+    await Promise.resolve()
+    await Promise.resolve()
+
+    pending[0].resolve({ nodes: [{ id: 'a1', entryType: 'message', isLeaf: true }] })
+    await p1
+    expect(useUIStore.getState().rewindTreeNodes).toEqual([
+      { id: 'b1', entryType: 'message', isLeaf: true },
+    ])
+    expect(useUIStore.getState().rewindKey).toBe('/b.jsonl')
+  })
+})

--- a/src/renderer/src/lib/rewind-metadata.ts
+++ b/src/renderer/src/lib/rewind-metadata.ts
@@ -1,20 +1,31 @@
 import { ipcClient } from '@renderer/lib/ipc-client'
 import { useUIStore } from '@renderer/stores/ui-store'
 
+/**
+ * 并发刷新防护：refreshSessionTree 无缓存地读 JSONL，连续发送（或切换会话）会
+ * 产生多个在途请求；较晚发出的请求若先返回，较早请求的旧文件快照会覆盖新树。
+ * 用单调递增序号，只接受最新一次请求的响应。
+ */
+let rewindTreeRequestSeq = 0
+
 /** 从当前会话 JSONL 加载树（与 TUI /tree 一致，不依赖 Worker 是否已 loadSession）。 */
 export async function refreshSessionTree(sessionFile: string | null): Promise<void> {
   const store = useUIStore.getState()
   const key = sessionFile || ''
+  const seq = ++rewindTreeRequestSeq
   store.setRewindMeta({ rewindKey: key, loadingTree: !!sessionFile })
 
   if (!sessionFile) {
-    store.setRewindMeta({ treeNodes: [], workerBound: false, loadingTree: false })
+    if (seq === rewindTreeRequestSeq) {
+      store.setRewindMeta({ treeNodes: [], workerBound: false, loadingTree: false })
+    }
     return
   }
 
   try {
     const treeRes = await ipcClient.invoke('session.tree', { sessionFile })
-    if (useUIStore.getState().rewindKey !== key) return
+    // 过期响应丢弃：期间已有更新的请求发出，或已切到其它会话。
+    if (seq !== rewindTreeRequestSeq || useUIStore.getState().rewindKey !== key) return
     const nodes = (treeRes?.nodes || []) as Array<{
       id: string
       depth: number
@@ -35,7 +46,7 @@ export async function refreshSessionTree(sessionFile: string | null): Promise<vo
     })
   } catch (e) {
     console.error('[refreshSessionTree]', e)
-    if (useUIStore.getState().rewindKey === key) {
+    if (seq === rewindTreeRequestSeq && useUIStore.getState().rewindKey === key) {
       store.setRewindMeta({ loadingTree: false, treeError: 'error' })
     }
   }


### PR DESCRIPTION
## 用户场景 / 问题
打开会话树面板时显示的是旧快照：新消息早已写入 JSONL，树上却没有——因为 store 里已有非空树数据时不再刷新。快速切换会话时还可能出现旧会话的树数据覆盖新会话（竞态）。

## 修复方案
- 面板挂载及 sessionFile 变化时**总是**刷新树（树数据是发送时点的快照，非空≠新鲜）。
- `refreshSessionTree` 加代际防护：过期请求的结果直接丢弃，不覆盖新会话数据（带测试）。