### PR TITLE
fix(composer): clear stale runtime entry when worker snapshot is idle

### DIFF
--- a/src/renderer/src/lib/__tests__/session-worker-sync.test.ts
+++ b/src/renderer/src/lib/__tests__/session-worker-sync.test.ts
@@ -188,6 +188,7 @@ describe('session-worker-sync', () => {
   it('applyLiveSnapshotToView ignores foreign session running snap', () => {
     let snap: { sessionId: string | null; sessionFile: string | null; status: string } | null = null
     let runStatus: string | null = null
+    const cleared: string[] = []
     applyLiveSnapshotToView(
       '/b.jsonl',
       { sessionId: 's1', sessionFile: '/a.jsonl', status: 'running' },
@@ -200,9 +201,63 @@ describe('session-worker-sync', () => {
         setRunState: (p) => {
           runStatus = p.status ?? null
         },
+        setSessionRuntimeRunning: (file, running) => {
+          if (!running) cleared.push(file)
+        },
       },
     )
     expect(snap).toEqual({ sessionId: null, sessionFile: '/b.jsonl', status: 'idle' })
     expect(runStatus).toBeNull()
+    // Foreign running snap: must not touch the view's runtime map.
+    expect(cleared).toEqual([])
+  })
+
+  it('applyLiveSnapshotToView clears stale runtime entry when the worker is idle', () => {
+    // The run.idle AppEvent never arrived (or was routed as background), leaving
+    // sessionRuntimeRunning[view] = true — the Composer Stop button stays lit even
+    // though the turn finished. An idle worker snapshot must clear it.
+    let snap: { sessionId: string | null; sessionFile: string | null; status: string } | null = null
+    const cleared: string[] = []
+    applyLiveSnapshotToView(
+      '/view.jsonl',
+      { sessionId: 's1', sessionFile: '/view.jsonl', status: 'idle' },
+      {
+        historySessionFile: '/view.jsonl',
+        runState: { status: 'running', toolCount: 0, errorCount: 0 },
+        setWorkerLiveSnapshot: (s) => {
+          snap = s
+        },
+        setRunState: (p) => {
+          void p
+        },
+        setSessionRuntimeRunning: (file, running) => {
+          if (!running) cleared.push(file)
+        },
+      },
+    )
+    expect(snap).toEqual({ sessionId: 's1', sessionFile: '/view.jsonl', status: 'idle' })
+    expect(cleared).toEqual(['/view.jsonl'])
+  })
+
+  it('applyLiveSnapshotToView keeps runtime entry when the worker snap is running', () => {
+    const cleared: string[] = []
+    applyLiveSnapshotToView(
+      '/view.jsonl',
+      { sessionId: 's1', sessionFile: '/view.jsonl', status: 'running' },
+      {
+        historySessionFile: '/view.jsonl',
+        runState: { status: 'idle', toolCount: 0, errorCount: 0 },
+        setWorkerLiveSnapshot: (s) => {
+          void s
+        },
+        setRunState: (p) => {
+          void p
+        },
+        setSessionRuntimeRunning: (file, running) => {
+          if (!running) cleared.push(file)
+        },
+      },
+    )
+    expect(cleared).toEqual([])
   })
 })

--- a/src/renderer/src/lib/__tests__/session-worker-sync.test.ts
+++ b/src/renderer/src/lib/__tests__/session-worker-sync.test.ts
@@ -212,6 +212,38 @@ describe('session-worker-sync', () => {
     expect(cleared).toEqual([])
   })
 
+  it('fetchWorkerLiveSnapshot reports unknown (not idle) when IPC fails', async () => {
+    vi.mocked(ipcClient.invoke).mockRejectedValue(new Error('ipc down'))
+    const snap = await fetchWorkerLiveSnapshot('/w', '/b.jsonl')
+    expect(snap.status).toBe('unknown')
+  })
+
+  it('applyLiveSnapshotToView keeps old state when snapshot is unknown (failed query)', () => {
+    // 查询失败不能清掉运行态，否则正在跑的任务会失去停止入口并停掉轮询
+    let snap: { sessionId: string | null; sessionFile: string | null; status: string } | null = null
+    const cleared: string[] = []
+    applyLiveSnapshotToView(
+      '/view.jsonl',
+      { sessionId: null, sessionFile: '/view.jsonl', status: 'unknown' },
+      {
+        historySessionFile: '/view.jsonl',
+        runState: { status: 'running', toolCount: 0, errorCount: 0 },
+        setWorkerLiveSnapshot: (s) => {
+          snap = s
+        },
+        setRunState: (p) => {
+          void p
+        },
+        setSessionRuntimeRunning: (file, running) => {
+          if (!running) cleared.push(file)
+        },
+      },
+    )
+    // 旧 snapshot 与运行态都保留
+    expect(snap).toBeNull()
+    expect(cleared).toEqual([])
+  })
+
   it('applyLiveSnapshotToView clears stale runtime entry when the worker is idle', () => {
     // The run.idle AppEvent never arrived (or was routed as background), leaving
     // sessionRuntimeRunning[view] = true — the Composer Stop button stays lit even

--- a/src/renderer/src/lib/session-shell.ts
+++ b/src/renderer/src/lib/session-shell.ts
@@ -126,7 +126,7 @@ function resolveRunUI(
     optimisticPendingUserText: string | null
     agentTurnBootstrapping: boolean
     workerSessionFile: string | null
-    workerStatus: 'idle' | 'running' | 'failed'
+    workerStatus: 'idle' | 'running' | 'failed' | 'unknown'
   },
 ): SessionRunUI {
   if (input.runtime[sessionKey] === true) return 'running'

--- a/src/renderer/src/lib/session-worker-sync.ts
+++ b/src/renderer/src/lib/session-worker-sync.ts
@@ -198,6 +198,7 @@ type ViewStore = {
   runState: RunState
   setWorkerLiveSnapshot: (snap: WorkerLiveSnapshot) => void
   setRunState: (patch: Partial<RunState>) => void
+  setSessionRuntimeRunning: (file: string, running: boolean) => void
 }
 
 /**
@@ -233,6 +234,14 @@ export function applyLiveSnapshotToView(
 
   store.setWorkerLiveSnapshot(boundSnap)
   syncViewRunStateFromWorkerSnapshot(viewSessionFile, boundSnap, (p) => store.setRunState(p))
+
+  // Lost run.idle fallback: a worker idle snapshot (or abort-forced idle) proves the
+  // turn ended even if the run.idle AppEvent never arrived (worker crash / dropped
+  // event). Without this, a stale sessionRuntimeRunning entry keeps the Composer
+  // Stop button lit after the conversation finished.
+  if (boundSnap.status === 'idle' && viewSessionFile) {
+    store.setSessionRuntimeRunning(viewSessionFile, false)
+  }
 }
 
 export function resetVisibleComposerTurnState(set: {

--- a/src/renderer/src/lib/session-worker-sync.ts
+++ b/src/renderer/src/lib/session-worker-sync.ts
@@ -6,7 +6,7 @@ import type { RunState } from '@renderer/stores/ui-store-types'
 export type WorkerLiveSnapshot = {
   sessionId: string | null
   sessionFile: string | null
-  status: 'idle' | 'running' | 'failed'
+  status: 'idle' | 'running' | 'failed' | 'unknown'
 }
 
 function runtimeRunningForSession(
@@ -45,7 +45,9 @@ export async function fetchWorkerLiveSnapshot(
     | undefined
 
   if (!st) {
-    return { sessionId: null, sessionFile: requested, status: 'idle' }
+    // IPC 失败/无响应与 worker 明确 idle 是两回事：失败必须保留旧状态，
+    // 否则一次瞬态查询失败就会清掉运行态并停掉轮询，正在跑的任务失去停止入口。
+    return { sessionId: null, sessionFile: requested, status: 'unknown' }
   }
 
   const repliedFile = st.sessionFile ? normalizeSessionFileKey(st.sessionFile) || st.sessionFile : null
@@ -178,6 +180,8 @@ export function syncViewRunStateFromWorkerSnapshot(
   }
   if (snap.status === 'running') {
     setRunState({ status: 'running', activeTool: undefined, activeToolStatus: undefined })
+  } else if (snap.status === 'unknown') {
+    // 查询失败：保留当前 runState，不降级为 idle
   } else {
     setRunState({
       status: snap.status === 'failed' ? 'failed' : 'idle',
@@ -211,6 +215,11 @@ export function applyLiveSnapshotToView(
   store: ViewStore,
 ): void {
   const normalized = normalizeWorkerLiveSnapshotForView(snap)
+
+  if (normalized.status === 'unknown') {
+    // 查询失败/无响应：保留旧 snapshot 与运行态，等下一次成功轮询再收敛
+    return
+  }
 
   if (viewSessionFile) {
     if (normalized.sessionFile && !sessionFilesEqual(normalized.sessionFile, viewSessionFile)) {


### PR DESCRIPTION
## 用户场景 / 问题
偶发：会话早已结束，composer 却一直显示"运行中"状态（停止按钮常驻），需要重启 app 才恢复。

## 代码问题
worker 快照上报 idle 时，renderer 侧 `sessionRuntimeRunning` 里的旧条目没有被清除——事件丢失或时序错位后状态永久卡死。

## 修复方案
处理 worker 快照时，若快照为 idle 则清除对应会话的 runtime running 条目，以快照为准收敛状态（带测试，12 个用例覆盖同步路径）。