### PR TITLE
fix(desktop): 隔离多会话运行控制与上下文预览

### DIFF
--- a/packages/shared/ipc-contract.ts
+++ b/packages/shared/ipc-contract.ts
@@ -3,6 +3,7 @@
 import type { AppEvent } from './app-events'
 import type { DiffResult } from './diff-model'
 import type { CompatibilityLevel } from './extension-types'
+import type { SessionContextPreview } from './session-context-preview'
 
 // ── Workspace ──
 export interface WorkspaceOpenRequest { path?: string; awaitWorker?: boolean }
@@ -87,6 +88,8 @@ export interface SessionCompactRequest { sessionId: string }
 export interface SessionCompactResponse { sessionId: string; compacted: boolean; tokensSaved: number }
 export interface SessionExportRequest { sessionId: string; format: 'json' | 'markdown' | 'html' }
 export interface SessionExportResponse { content: string; format: string; filename: string }
+export interface ContextPreviewRequest { sessionFile: string; workspaceId: string }
+export interface ContextPreviewResponse { preview: SessionContextPreview | null }
 
 // ── Prompt ──
 export interface PromptSendRequest { sessionId: string; text: string }
@@ -95,8 +98,8 @@ export interface PromptSteerRequest { sessionId: string; text: string }
 export interface PromptSteerResponse { steered: boolean }
 export interface PromptFollowUpRequest { sessionId: string; text: string }
 export interface PromptFollowUpResponse { messageId: string }
-export interface PromptAbortRequest { sessionId: string }
-export interface PromptAbortResponse { aborted: boolean }
+export interface PromptAbortRequest { sessionId: string; sessionFile: string }
+export interface PromptAbortResponse { aborted: boolean; ignored?: boolean; reason?: string; noWorker?: boolean }
 
 // ── Model ──
 export interface ModelInfo {
@@ -307,6 +310,7 @@ export interface IpcMethodMap {
   'session.rename': { request: SessionRenameRequest; response: SessionRenameResponse }
   'session.compact': { request: SessionCompactRequest; response: SessionCompactResponse }
   'session.export': { request: SessionExportRequest; response: SessionExportResponse }
+  'context.preview': { request: ContextPreviewRequest; response: ContextPreviewResponse }
   'prompt.send': { request: PromptSendRequest; response: PromptSendResponse }
   'prompt.steer': { request: PromptSteerRequest; response: PromptSteerResponse }
   'prompt.followUp': { request: PromptFollowUpRequest; response: PromptFollowUpResponse }

--- a/packages/shared/session-context-preview.test.ts
+++ b/packages/shared/session-context-preview.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { buildSessionContextPreview } from './session-context-preview'
+
+describe('buildSessionContextPreview', () => {
+  it('builds the same scoped preview for live and disk session messages', () => {
+    const preview = buildSessionContextPreview({
+      sessionId: 'session-a',
+      sessionFile: '/sessions/a.jsonl',
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: [{ type: 'text', text: 'world' }] },
+        { role: 'toolResult', toolName: 'read', content: 'result' },
+        { role: 'compactionSummary', content: 'summary' },
+      ],
+    })
+
+    expect(preview).toEqual(expect.objectContaining({
+      sessionId: 'session-a',
+      sessionFile: '/sessions/a.jsonl',
+      messageCount: 4,
+      estimatedChars: 23,
+      roleBreakdown: [
+        { role: 'user', chars: 5 },
+        { role: 'assistant', chars: 5 },
+        { role: 'tool', chars: 6 },
+        { role: 'summary', chars: 7 },
+      ],
+    }))
+    expect(preview.segments.map((segment) => segment.role)).toEqual([
+      'user',
+      'assistant',
+      'toolResult',
+      'compactionSummary',
+    ])
+  })
+})

--- a/packages/shared/session-context-preview.ts
+++ b/packages/shared/session-context-preview.ts
@@ -1,0 +1,97 @@
+import { extractTextFromPiMessage, type PiSessionMessage } from './worker-message'
+
+export type SessionContextSegment = {
+  index: number
+  role: string
+  chars: number
+  preview: string
+  label?: string
+}
+
+export type SessionContextRoleSlice = {
+  role: string
+  chars: number
+}
+
+export type SessionContextPreview = {
+  sessionId: string | null
+  sessionFile: string
+  messageCount: number
+  estimatedChars: number
+  snippets: string[]
+  segments: SessionContextSegment[]
+  roleBreakdown: SessionContextRoleSlice[]
+}
+
+type BuildPreviewInput = {
+  sessionId?: string | null
+  sessionFile: string
+  messages?: readonly PiSessionMessage[] | null
+}
+
+function roleBucket(role: string): string {
+  if (role === 'user') return 'user'
+  if (role === 'assistant') return 'assistant'
+  if (role === 'toolResult' || role === 'tool') return 'tool'
+  if (role === 'system') return 'system'
+  if (role === 'compactionSummary' || role === 'branchSummary') return 'summary'
+  return 'other'
+}
+
+function messageLabel(message: PiSessionMessage): string | undefined {
+  if (message.role === 'toolResult' && message.toolName) return message.toolName
+  if (message.role !== 'assistant' || !Array.isArray(message.content)) return undefined
+  const tools = message.content
+    .filter((content) => content.type === 'toolCall')
+    .map((content) => (content as { toolCall?: { name?: string } }).toolCall?.name)
+    .filter((name): name is string => !!name)
+  return tools.length > 0 ? tools.join(', ') : undefined
+}
+
+export function buildSessionContextPreview(input: BuildPreviewInput): SessionContextPreview {
+  const snippets: string[] = []
+  const segments: SessionContextSegment[] = []
+  const roleChars: Record<string, number> = {}
+  let estimatedChars = 0
+
+  const append = (role: string, text: string, label?: string): void => {
+    const chars = text.length
+    estimatedChars += chars
+    if (chars > 0) {
+      const bucket = roleBucket(role)
+      roleChars[bucket] = (roleChars[bucket] || 0) + chars
+    }
+    segments.push({
+      index: segments.length,
+      role,
+      chars,
+      preview: text.slice(0, 280),
+      label,
+    })
+  }
+
+  const messages = input.messages || []
+  for (const message of messages) {
+    const role = message.role || '?'
+    const text = extractTextFromPiMessage(message)
+    append(role, text, messageLabel(message))
+    if (snippets.length < 12 && text) {
+      snippets.push(`[${role}] ${text.slice(0, 200)}${text.length > 200 ? '...' : ''}`)
+    }
+  }
+
+  const roleOrder = ['system', 'user', 'assistant', 'tool', 'summary', 'other']
+  const roleBreakdown = roleOrder
+    .filter((role) => (roleChars[role] || 0) > 0)
+    .map((role) => ({ role, chars: roleChars[role] || 0 }))
+
+  return {
+    sessionId: input.sessionId || null,
+    sessionFile: input.sessionFile,
+    messageCount: messages.length,
+    estimatedChars,
+    snippets,
+    segments,
+    roleBreakdown,
+  }
+}

--- a/packages/shared/worker-rpc-types.ts
+++ b/packages/shared/worker-rpc-types.ts
@@ -1,6 +1,7 @@
 /** Worker ↔ Main JSON-RPC style payloads (loosely typed JSON). */
 
 import type { PiSessionMessage } from './worker-message'
+import type { SessionContextPreview } from './session-context-preview'
 
 export type WorkerCommandInfo = {
   name: string
@@ -24,7 +25,7 @@ export type WorkerPromptTemplate = {
 
 export type WorkerState = Record<string, unknown>
 
-export type WorkerContextPreview = Record<string, unknown> | null
+export type WorkerContextPreview = SessionContextPreview | null
 
 export type WorkerModelRow = {
   id?: string

--- a/src/main/__tests__/trusted-workspace.test.ts
+++ b/src/main/__tests__/trusted-workspace.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  cwd: '/workspace' as string | null,
+  currentProject: null as string | null,
+  readSessionMetaFromFile: vi.fn(),
+}))
+
+vi.mock('../worker-manager', () => ({
+  workerManager: {
+    get cwd() {
+      return mocks.cwd
+    },
+  },
+}))
+
+vi.mock('../config-store', () => ({
+  configStore: { get: vi.fn(() => mocks.currentProject) },
+}))
+
+vi.mock('../session-file-meta', () => ({
+  readSessionMetaFromFile: mocks.readSessionMetaFromFile,
+}))
+
+import { authorizeTrustedSessionFile } from '../trusted-workspace'
+
+describe('authorizeTrustedSessionFile', () => {
+  beforeEach(() => {
+    mocks.cwd = '/workspace'
+    mocks.currentProject = null
+    mocks.readSessionMetaFromFile.mockReset()
+    mocks.readSessionMetaFromFile.mockReturnValue({ sessionId: 'session-a', cwd: '/workspace' })
+  })
+
+  it('accepts an absolute session whose header belongs to the active workspace', () => {
+    expect(authorizeTrustedSessionFile('/workspace', '/sessions/a.jsonl')).toEqual({
+      ok: true,
+      cwd: '/workspace',
+      sessionFile: '/sessions/a.jsonl',
+    })
+  })
+
+  it('rejects another workspace, a relative path, and a mismatched session header', () => {
+    expect(authorizeTrustedSessionFile('/other', '/sessions/a.jsonl')).toEqual({
+      ok: false,
+      error: 'cwd_not_trusted',
+    })
+    expect(authorizeTrustedSessionFile('/workspace', 'session.jsonl')).toEqual({
+      ok: false,
+      error: 'invalid_session_path',
+    })
+
+    mocks.readSessionMetaFromFile.mockReturnValue({ sessionId: 'session-b', cwd: '/other' })
+    expect(authorizeTrustedSessionFile('/workspace', '/sessions/b.jsonl')).toEqual({
+      ok: false,
+      error: 'session_workspace_mismatch',
+    })
+  })
+
+  it('matches native WSL header paths but rejects another session-file distro', () => {
+    mocks.cwd = '\\\\wsl.localhost\\Ubuntu\\home\\u\\project'
+    mocks.readSessionMetaFromFile.mockReturnValue({ sessionId: 'session-a', cwd: '/home/u/project' })
+
+    expect(
+      authorizeTrustedSessionFile(
+        mocks.cwd,
+        '\\\\wsl.localhost\\Ubuntu\\home\\u\\.pi\\agent\\sessions\\a.jsonl',
+      ),
+    ).toEqual(expect.objectContaining({ ok: true }))
+    expect(
+      authorizeTrustedSessionFile(
+        mocks.cwd,
+        '\\\\wsl.localhost\\Debian\\home\\u\\.pi\\agent\\sessions\\a.jsonl',
+      ),
+    ).toEqual({ ok: false, error: 'session_workspace_mismatch' })
+  })
+})

--- a/src/main/__tests__/worker-manager-session-isolation.test.ts
+++ b/src/main/__tests__/worker-manager-session-isolation.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkerSlot } from '../worker-manager-types'
+import { WorkerManager } from '../worker-manager'
+import { attachWorkerHandlers } from '../worker-manager-pool'
+import { normalizeSessionKey, workspacePoolKey } from '../worker-session-key'
+
+vi.mock('../config-store', () => ({
+  configStore: { get: vi.fn(() => undefined) },
+}))
+
+const { forkWorkerForCwd } = vi.hoisted(() => ({ forkWorkerForCwd: vi.fn() }))
+
+vi.mock('../worker-manager-pool', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../worker-manager-pool')>()
+  return { ...actual, forkWorkerForCwd }
+})
+
+type FakeTransport = WorkerSlot['worker'] & {
+  postMessage: ReturnType<typeof vi.fn>
+  emitMessage: (message: Record<string, unknown>) => void
+}
+
+type Internals = {
+  pool: Map<string, WorkerSlot>
+  foregroundPoolKey: string | null
+}
+
+function fakeSlot(poolKey: string, active = false): WorkerSlot {
+  let onMessage: Parameters<WorkerSlot['worker']['onMessage']>[0] | null = null
+  const worker: FakeTransport = {
+    kind: 'utilityProcess',
+    postMessage: vi.fn((_message: Record<string, unknown>) => {}),
+    onMessage: (callback) => {
+      onMessage = callback
+    },
+    onExit: vi.fn(),
+    onStdout: vi.fn(),
+    onStderr: vi.fn(),
+    kill: vi.fn(),
+    emitMessage: (message) => onMessage?.(message as never),
+  }
+  return {
+    poolKey,
+    cwd: '/workspace',
+    runtime: { mode: 'host', distro: null },
+    sessionFile: poolKey.startsWith('ws:') ? null : poolKey,
+    worker,
+    pendingRequests: new Map(),
+    requestCounter: 0,
+    initResolver: null,
+    initRejecter: null,
+    initPromise: null,
+    agentTurnActive: active,
+    lastIdleAt: Date.now(),
+    lastForegroundAt: Date.now(),
+    sdkFallback: false,
+    autoRestartEnabled: true,
+    stopping: false,
+  }
+}
+
+function replyFrom(slot: WorkerSlot, reply: Record<string, unknown>): void {
+  const worker = slot.worker as FakeTransport
+  attachWorkerHandlers(slot, worker, {
+    mainWindow: null,
+    onAppEvent: vi.fn(),
+    onSlotExit: vi.fn(),
+  })
+  worker.postMessage.mockImplementation((message: { requestId?: string }) => {
+    queueMicrotask(() => worker.emitMessage({ requestId: message.requestId, ...reply }))
+  })
+}
+
+function managerWithForeground(slot: WorkerSlot): { manager: WorkerManager; internals: Internals } {
+  const manager = new WorkerManager()
+  const internals = manager as unknown as Internals
+  internals.pool.set(slot.poolKey, slot)
+  internals.foregroundPoolKey = slot.poolKey
+  return { manager, internals }
+}
+
+describe('WorkerManager session isolation', () => {
+  beforeEach(() => forkWorkerForCwd.mockReset())
+
+  it('queries context only from the worker bound to the requested session', async () => {
+    const foreground = fakeSlot(normalizeSessionKey('/sessions/a.jsonl'))
+    const target = fakeSlot(normalizeSessionKey('/sessions/b.jsonl'))
+    const { manager, internals } = managerWithForeground(foreground)
+    internals.pool.set(target.poolKey, target)
+    replyFrom(foreground, { type: 'getSessionContextPreview-done', preview: { estimatedChars: 11 } })
+    replyFrom(target, { type: 'getSessionContextPreview-done', preview: { estimatedChars: 22 } })
+
+    const preview = await manager.getSessionContextPreview(target.poolKey)
+
+    expect(preview).toEqual(expect.objectContaining({ sessionFile: target.poolKey, estimatedChars: 22 }))
+    expect(foreground.worker.postMessage).not.toHaveBeenCalled()
+    expect(await manager.getSessionContextPreview('/sessions/missing.jsonl')).toBeNull()
+  })
+
+  it('creates a separate worker when the foreground session is running', async () => {
+    const running = fakeSlot(normalizeSessionKey('/sessions/running.jsonl'), true)
+    const { manager, internals } = managerWithForeground(running)
+    const created = fakeSlot(workspacePoolKey('/workspace'))
+    const createdFile = normalizeSessionKey('/sessions/new.jsonl')
+    replyFrom(created, { type: 'newSession-done', sessionId: 'new', sessionFile: createdFile })
+    forkWorkerForCwd.mockResolvedValue({ slot: created, init: Promise.resolve({ sessionId: 'temp' }) })
+
+    expect(await manager.newSession('/workspace')).toEqual({ sessionId: 'new', sessionFile: createdFile })
+    expect(running.worker.postMessage).not.toHaveBeenCalled()
+    expect(internals.pool.get(running.poolKey)).toBe(running)
+    expect(internals.pool.get(createdFile)).toBe(created)
+  })
+
+  it('keeps both slots when new sessions are created concurrently', async () => {
+    const { manager, internals } = managerWithForeground(
+      fakeSlot(normalizeSessionKey('/sessions/running.jsonl'), true),
+    )
+    let sequence = 0
+    forkWorkerForCwd.mockImplementation(async (_cwd: string, options?: { poolKey?: string }) => {
+      const index = ++sequence
+      const slot = fakeSlot(options?.poolKey || workspacePoolKey('/workspace'))
+      replyFrom(slot, {
+        type: 'newSession-done',
+        sessionId: `new-${index}`,
+        sessionFile: normalizeSessionKey(`/sessions/new-${index}.jsonl`),
+      })
+      return { slot, init: Promise.resolve({ sessionId: `temp-${index}` }) }
+    })
+
+    const results = await Promise.all([manager.newSession('/workspace'), manager.newSession('/workspace')])
+
+    expect(results.map((result) => result.sessionId)).toEqual(['new-1', 'new-2'])
+    expect(internals.pool.has(normalizeSessionKey('/sessions/new-1.jsonl'))).toBe(true)
+    expect(internals.pool.has(normalizeSessionKey('/sessions/new-2.jsonl'))).toBe(true)
+  })
+
+  it('sends abort only to the worker bound to the requested session', async () => {
+    const foreground = fakeSlot(normalizeSessionKey('/sessions/a.jsonl'), true)
+    const requested = fakeSlot(normalizeSessionKey('/sessions/b.jsonl'), true)
+    const { manager, internals } = managerWithForeground(foreground)
+    internals.pool.set(requested.poolKey, requested)
+    replyFrom(requested, { type: 'abort-done' })
+
+    await manager.abort(requested.poolKey)
+
+    expect(foreground.worker.postMessage).not.toHaveBeenCalled()
+    expect(requested.worker.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'abort', sessionFile: requested.poolKey }),
+    )
+  })
+})

--- a/src/main/ipc/handlers/context-preview-isolation.test.ts
+++ b/src/main/ipc/handlers/context-preview-isolation.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, (request?: Record<string, unknown>) => Promise<unknown>>(),
+  getSessionContextPreview: vi.fn(),
+  sessionOpen: vi.fn(),
+  getSessionLeafOverride: vi.fn(),
+  authorizeTrustedSessionFile: vi.fn(),
+}))
+
+vi.mock('../registry', () => ({
+  registerHandler: (
+    channel: string,
+    handler: (request?: Record<string, unknown>) => Promise<unknown>,
+  ) => mocks.handlers.set(channel, handler),
+  registerHandlerWithSchema: (
+    channel: string,
+    schema: { safeParse: (request: unknown) => { success: boolean; data?: Record<string, unknown> } },
+    handler: (request: Record<string, unknown>) => Promise<unknown>,
+  ) => mocks.handlers.set(channel, async (request) => {
+    const parsed = schema.safeParse(request)
+    if (!parsed.success) throw new Error(`Invalid IPC input for ${channel}`)
+    return handler(parsed.data || {})
+  }),
+}))
+
+vi.mock('../../worker-manager', () => ({
+  workerManager: {
+    isRunning: false,
+    cwd: null,
+    getSessionContextPreview: mocks.getSessionContextPreview,
+  },
+}))
+
+vi.mock('../../config-store', () => ({
+  configStore: { get: vi.fn(() => undefined) },
+}))
+
+vi.mock('../../sandbox-workspaces', () => ({
+  isSandboxWorkspacePath: vi.fn(() => false),
+}))
+
+vi.mock('../../pi-models-json', () => ({
+  readModelsConfigRaw: vi.fn(() => ({ config: {}, parseError: null })),
+  modelsCatalogFromConfig: vi.fn(() => []),
+}))
+
+vi.mock('../../active-sdk-models', () => ({
+  listAvailableModelsWithSdk: vi.fn(async () => []),
+  listCatalogModelsWithSdk: vi.fn(async () => []),
+  resolveAvailableModels: vi.fn(async () => []),
+  resolveCatalogModels: vi.fn(async () => []),
+}))
+
+vi.mock('../../session-leaf-override', () => ({
+  getSessionLeafOverride: mocks.getSessionLeafOverride,
+}))
+
+vi.mock('../../trusted-workspace', () => ({
+  authorizeTrustedSessionFile: mocks.authorizeTrustedSessionFile,
+}))
+
+vi.mock('../sdk-session', () => ({
+  getActiveSdkModule: vi.fn(async () => ({
+    SessionManager: { open: mocks.sessionOpen },
+  })),
+}))
+
+import { workerManager } from '../../worker-manager'
+import { registerModelRuntimeHandlers } from './model-runtime'
+
+describe('context.preview session isolation', () => {
+  beforeEach(() => {
+    mocks.handlers.clear()
+    mocks.getSessionContextPreview.mockReset()
+    mocks.sessionOpen.mockReset()
+    mocks.getSessionLeafOverride.mockReset()
+    mocks.authorizeTrustedSessionFile.mockReset()
+    mocks.authorizeTrustedSessionFile.mockImplementation((_workspaceId, sessionFile) => ({
+      ok: true,
+      cwd: '/workspace',
+      sessionFile,
+    }))
+    ;(workerManager as { isRunning: boolean }).isRunning = false
+    registerModelRuntimeHandlers()
+  })
+
+  it('queries the live preview only for the requested session', async () => {
+    const sessionFile = '/sessions/target.jsonl'
+    ;(workerManager as { isRunning: boolean }).isRunning = true
+    mocks.getSessionContextPreview.mockImplementation(async (requested?: string) => ({
+      sessionFile: requested || '/sessions/foreground.jsonl',
+      messageCount: 1,
+      estimatedChars: requested ? 22 : 11,
+    }))
+
+    const result = await mocks.handlers.get('ipc:context.preview')!({
+      sessionFile,
+      workspaceId: '/workspace',
+    })
+
+    expect(mocks.getSessionContextPreview).toHaveBeenCalledWith(sessionFile)
+    expect(mocks.authorizeTrustedSessionFile).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      preview: expect.objectContaining({ sessionFile, estimatedChars: 22 }),
+    })
+  })
+
+  it('reads an idle session from disk without requiring a running worker', async () => {
+    const sessionFile = '/sessions/idle.jsonl'
+    mocks.getSessionContextPreview.mockResolvedValue(null)
+    mocks.getSessionLeafOverride.mockReturnValue('rewound-leaf')
+    const branch = vi.fn()
+    mocks.sessionOpen.mockReturnValue({
+      branch,
+      resetLeaf: vi.fn(),
+      getSessionId: () => 'idle-session',
+      buildSessionContext: () => ({
+        messages: [{ role: 'user', content: 'idle context' }],
+      }),
+    })
+
+    const result = await mocks.handlers.get('ipc:context.preview')!({
+      sessionFile,
+      workspaceId: '/workspace',
+    })
+
+    expect(mocks.authorizeTrustedSessionFile).toHaveBeenCalledWith('/workspace', sessionFile)
+    expect(branch).toHaveBeenCalledWith('rewound-leaf')
+    expect(result).toEqual({
+      preview: expect.objectContaining({
+        sessionFile,
+        sessionId: 'idle-session',
+        messageCount: 1,
+        estimatedChars: 12,
+      }),
+    })
+  })
+
+  it('does not open a session file outside the active trusted workspace', async () => {
+    mocks.authorizeTrustedSessionFile.mockReturnValue({
+      ok: false,
+      error: 'session_workspace_mismatch',
+    })
+
+    const result = await mocks.handlers.get('ipc:context.preview')!({
+      sessionFile: '/other/session.jsonl',
+      workspaceId: '/workspace',
+    })
+
+    expect(result).toEqual({ preview: null })
+    expect(mocks.sessionOpen).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/handlers/model-runtime.ts
+++ b/src/main/ipc/handlers/model-runtime.ts
@@ -1,9 +1,13 @@
-import { registerHandler } from '../registry'
+import { registerHandler, registerHandlerWithSchema } from '../registry'
 import { workerManager } from '../../worker-manager'
 import { configStore } from '../../config-store'
 import { isSandboxWorkspacePath } from '../../sandbox-workspaces'
 import { readModelsConfigRaw, modelsCatalogFromConfig } from '../../pi-models-json'
 import { getActiveSdkModule } from '../sdk-session'
+import { getSessionContextPreviewFromDisk } from '../../session-context-preview'
+import { getSessionLeafOverride } from '../../session-leaf-override'
+import { authorizeTrustedSessionFile } from '../../trusted-workspace'
+import { contextPreviewSchema } from '../schemas'
 import {
   listAvailableModelsWithSdk,
   listCatalogModelsWithSdk,
@@ -113,10 +117,25 @@ export function registerModelRuntimeHandlers(): void {
     return { state: await workerManager.getState() }
   })
 
-  registerHandler('ipc:context.preview', async () => {
-    if (!workerManager.isRunning) return { preview: null }
+  registerHandlerWithSchema('ipc:context.preview', contextPreviewSchema, async (req) => {
+    const { sessionFile, workspaceId } = req
+    if (workerManager.isRunning) {
+      try {
+        const preview = await workerManager.getSessionContextPreview(sessionFile)
+        if (preview) return { preview }
+      } catch (e) {
+        console.warn('[IPC] live context.preview failed, using disk:', e)
+      }
+    }
+    const authorized = authorizeTrustedSessionFile(workspaceId, sessionFile)
+    if (!authorized.ok) return { preview: null }
     try {
-      return { preview: await workerManager.getSessionContextPreview() }
+      return {
+        preview: await getSessionContextPreviewFromDisk(
+          authorized.sessionFile,
+          getSessionLeafOverride(authorized.sessionFile),
+        ),
+      }
     } catch (e) {
       console.error('[IPC] context.preview failed:', e)
       return { preview: null }

--- a/src/main/ipc/handlers/prompt-abort-isolation.test.ts
+++ b/src/main/ipc/handlers/prompt-abort-isolation.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, (request: Record<string, unknown>) => Promise<unknown>>(),
+  abort: vi.fn(),
+  getState: vi.fn(),
+}))
+
+vi.mock('../registry', () => ({
+  registerHandler: (
+    channel: string,
+    handler: (request: Record<string, unknown>) => Promise<unknown>,
+  ) => mocks.handlers.set(channel, handler),
+  registerHandlerWithSchema: vi.fn(),
+}))
+vi.mock('../../worker-manager', () => ({
+  workerManager: {
+    abort: mocks.abort,
+    getState: mocks.getState,
+  },
+}))
+vi.mock('../../session-bind-state', () => ({
+  ensureWorkerSessionBound: vi.fn(),
+}))
+vi.mock('../../clipboard-temp-images', () => ({
+  writeClipboardTempImage: vi.fn(),
+}))
+
+import { registerPromptHandlers } from './prompt'
+
+describe('prompt.abort session isolation', () => {
+  beforeEach(() => {
+    mocks.handlers.clear()
+    mocks.abort.mockReset()
+    mocks.getState.mockReset()
+    registerPromptHandlers()
+  })
+
+  it('rejects an abort request without a session file instead of targeting foreground', async () => {
+    const handler = mocks.handlers.get('ipc:prompt.abort')
+    expect(handler).toBeDefined()
+
+    const result = await handler!({ sessionId: '' })
+
+    expect(result).toEqual({
+      aborted: false,
+      ignored: true,
+      reason: 'session_required',
+    })
+    expect(mocks.abort).not.toHaveBeenCalled()
+  })
+
+  it('aborts only the explicitly requested session', async () => {
+    const handler = mocks.handlers.get('ipc:prompt.abort')!
+    mocks.getState.mockResolvedValue({
+      sessionFile: '/sessions/current.jsonl',
+      isStreaming: true,
+    })
+
+    const result = await handler({
+      sessionId: 'current',
+      sessionFile: '/sessions/current.jsonl',
+    })
+
+    expect(result).toEqual({ aborted: true })
+    expect(mocks.abort).toHaveBeenCalledWith('/sessions/current.jsonl')
+  })
+})

--- a/src/main/ipc/handlers/prompt.ts
+++ b/src/main/ipc/handlers/prompt.ts
@@ -83,17 +83,18 @@ export function registerPromptHandlers(): void {
 
   registerHandler('ipc:prompt.abort', async (req) => {
     const sessionFile = req?.sessionFile as string | undefined
+    if (!sessionFile) {
+      return { aborted: false, ignored: true, reason: 'session_required' }
+    }
     // Always attempt abort for the requested session. Path-normalize match only
     // blocks when getState clearly points at a *different* live session.
-    if (sessionFile) {
-      const want = normalizeSessionKey(sessionFile)
-      const st = await workerManager.getState(sessionFile).catch(() => null)
-      const got = normalizeSessionKey(String((st as { sessionFile?: string } | null)?.sessionFile || ''))
-      const streaming = !!(st as { isStreaming?: boolean } | null)?.isStreaming
-      // Foreign running session — refuse (safety). Idle/missing slot — still abort by key.
-      if (got && want && got !== want && streaming) {
-        return { aborted: false, ignored: true, reason: 'session_mismatch' }
-      }
+    const want = normalizeSessionKey(sessionFile)
+    const st = await workerManager.getState(sessionFile).catch(() => null)
+    const got = normalizeSessionKey(String((st as { sessionFile?: string } | null)?.sessionFile || ''))
+    const streaming = !!(st as { isStreaming?: boolean } | null)?.isStreaming
+    // Foreign running session — refuse (safety). Idle/missing slot — still abort by key.
+    if (got && want && got !== want && streaming) {
+      return { aborted: false, ignored: true, reason: 'session_mismatch' }
     }
     try {
       await workerManager.abort(sessionFile)
@@ -117,7 +118,7 @@ export function registerPromptHandlers(): void {
     const all = [...(cleared.steering || []), ...(cleared.followUp || [])]
     const queuedText = all.join('\n')
     const combined = [queuedText, currentText.trim()].filter(Boolean).join('\n')
-    if (abort) await workerManager.abort(sessionFile)
+    if (abort && sessionFile) await workerManager.abort(sessionFile)
     return { restoredCount: all.length, combinedText: combined }
   })
 }

--- a/src/main/ipc/handlers/session.ts
+++ b/src/main/ipc/handlers/session.ts
@@ -262,7 +262,7 @@ export function registerSessionHandlers(): void {
       await workerManager.start(workspaceId)
     }
     setPendingWorkerSessionFile(null)
-    const result = await workerManager.newSession()
+    const result = await workerManager.newSession(workspaceId)
     invalidateListSessionsCache(workspaceId)
     const state = await workerManager.getState().catch(() => ({}))
     const sessionFile =

--- a/src/main/ipc/schemas.ts
+++ b/src/main/ipc/schemas.ts
@@ -66,6 +66,13 @@ export const sessionPrepareSchema = z.object({
   bind: z.boolean().optional(),
 })
 
+export const contextPreviewSchema = z
+  .object({
+    sessionFile: z.string().trim().min(1),
+    workspaceId: z.string().trim().min(1),
+  })
+  .strict()
+
 export const workspaceOpenSchema = z.object({
   path: z.string().min(1),
   awaitWorker: z.boolean().optional(),

--- a/src/main/session-context-preview.ts
+++ b/src/main/session-context-preview.ts
@@ -1,0 +1,20 @@
+import { buildSessionContextPreview, type SessionContextPreview } from '@shared/session-context-preview'
+import type { PiSessionMessage } from '@shared/worker-message'
+import { getActiveSdkModule } from './ipc/sdk-session'
+
+export async function getSessionContextPreviewFromDisk(
+  sessionFile: string,
+  leafId?: string | null,
+): Promise<SessionContextPreview> {
+  const { SessionManager } = await getActiveSdkModule()
+  const session = SessionManager.open(sessionFile)
+  if (leafId === null) session.resetLeaf()
+  else if (typeof leafId === 'string' && leafId.length > 0) session.branch(leafId)
+
+  const context = session.buildSessionContext()
+  return buildSessionContextPreview({
+    sessionId: session.getSessionId(),
+    sessionFile,
+    messages: (context.messages || []) as PiSessionMessage[],
+  })
+}

--- a/src/main/trusted-workspace.ts
+++ b/src/main/trusted-workspace.ts
@@ -1,5 +1,7 @@
-import { resolve } from 'path'
+import { isAbsolute, posix, resolve } from 'path'
+import { isWslWindowsPath, windowsPathToWsl, wslWindowsPathDistro } from '@shared/wsl-path'
 import { configStore } from './config-store'
+import { readSessionMetaFromFile } from './session-file-meta'
 import { workerManager } from './worker-manager'
 
 /** Active workspace root for capability-bound IPC (git mutations, image preview). */
@@ -17,4 +19,50 @@ export function authorizeTrustedCwd(reqCwd: string | undefined): { ok: true; cwd
   const b = resolve(String(reqCwd).trim())
   if (a !== b) return { ok: false, error: 'cwd_not_trusted' }
   return { ok: true, cwd: trusted }
+}
+
+type TrustedSessionFileResult =
+  | { ok: true; cwd: string; sessionFile: string }
+  | { ok: false; error: string }
+
+function isPortableAbsolutePath(value: string): boolean {
+  return isAbsolute(value) || /^[a-zA-Z]:[\\/]/.test(value) || isWslWindowsPath(value)
+}
+
+function comparableWorkspacePath(value: string): string {
+  const wslPath = windowsPathToWsl(null, value).replace(/\\/g, '/')
+  const normalized = posix.normalize(wslPath)
+  return normalized.length > 1 ? normalized.replace(/\/+$/, '') : normalized
+}
+
+function workspacePathsEqual(a: string, b: string): boolean {
+  return comparableWorkspacePath(a) === comparableWorkspacePath(b)
+}
+
+/** Authorize a renderer-provided session path before opening it in the main process. */
+export function authorizeTrustedSessionFile(
+  reqCwd: string | undefined,
+  requestedSessionFile: string | undefined,
+): TrustedSessionFileResult {
+  const authorizedCwd = authorizeTrustedCwd(reqCwd)
+  if (!authorizedCwd.ok) return authorizedCwd
+
+  const sessionFile = String(requestedSessionFile || '').trim()
+  if (!sessionFile || !isPortableAbsolutePath(sessionFile)) {
+    return { ok: false, error: 'invalid_session_path' }
+  }
+
+  const meta = readSessionMetaFromFile(sessionFile)
+  if (!meta?.cwd) return { ok: false, error: 'invalid_session' }
+  if (!workspacePathsEqual(meta.cwd, authorizedCwd.cwd)) {
+    return { ok: false, error: 'session_workspace_mismatch' }
+  }
+
+  const fileDistro = wslWindowsPathDistro(sessionFile)
+  const workspaceDistro = wslWindowsPathDistro(authorizedCwd.cwd)
+  if (fileDistro && workspaceDistro && fileDistro.toLowerCase() !== workspaceDistro.toLowerCase()) {
+    return { ok: false, error: 'session_workspace_mismatch' }
+  }
+
+  return { ok: true, cwd: authorizedCwd.cwd, sessionFile }
 }

--- a/src/main/worker-manager-new-session.ts
+++ b/src/main/worker-manager-new-session.ts
@@ -1,0 +1,113 @@
+import type { BrowserWindow } from 'electron'
+import {
+  attachWorkerHandlers,
+  canAcquireNewWorker,
+  disposeWorkerSlot,
+  evictIdleWorkers,
+  forkWorkerForCwd,
+  remapSessionWorkerSlot,
+  slotRequest,
+} from './worker-manager-pool'
+import type { WorkerAppEventForward, WorkerSlot } from './worker-manager-types'
+import { readMaxSessionWorkers } from './worker-pool-config'
+import { normalizeSessionKey, workspacePoolKey } from './worker-session-key'
+
+export type NewSessionPoolOptions = {
+  cwd: string
+  pool: Map<string, WorkerSlot>
+  mainWindow: BrowserWindow | null
+  foregroundPoolKey: () => string | null
+  slotMatchesCurrentRuntime: (slot: WorkerSlot) => boolean
+  setForeground: (slot: WorkerSlot) => void
+  onAppEvent: (payload: WorkerAppEventForward) => void
+  onSlotExit: (slot: WorkerSlot, code: number) => void
+}
+
+function findReusableWorkspaceSlot(options: NewSessionPoolOptions): WorkerSlot | null {
+  const foregroundKey = options.foregroundPoolKey()
+  const foreground = foregroundKey ? options.pool.get(foregroundKey) : null
+  if (
+    foreground &&
+    foreground.cwd === options.cwd &&
+    options.slotMatchesCurrentRuntime(foreground) &&
+    !foreground.sessionFile &&
+    !foreground.agentTurnActive &&
+    !foreground.stopping
+  ) {
+    return foreground
+  }
+  for (const slot of options.pool.values()) {
+    if (
+      slot.cwd === options.cwd &&
+      options.slotMatchesCurrentRuntime(slot) &&
+      !slot.sessionFile &&
+      !slot.agentTurnActive &&
+      !slot.stopping
+    ) {
+      return slot
+    }
+  }
+  return null
+}
+
+function nextWorkspacePoolKey(pool: Map<string, WorkerSlot>, cwd: string): string {
+  const base = workspacePoolKey(cwd)
+  if (!pool.has(base)) return base
+  for (let suffix = 1; ; suffix++) {
+    const candidate = `${base}:new:${suffix}`
+    if (!pool.has(candidate)) return candidate
+  }
+}
+
+async function runNewSession(
+  slot: WorkerSlot,
+  options: NewSessionPoolOptions,
+): Promise<{ sessionId: string; sessionFile?: string }> {
+  if (slot.initPromise) await slot.initPromise
+  const response = await slotRequest(slot, 'newSession')
+  const sessionId = String(response.sessionId ?? '')
+  const sessionFile = response.sessionFile
+    ? normalizeSessionKey(String(response.sessionFile))
+    : undefined
+  if (sessionFile) {
+    await remapSessionWorkerSlot(options.pool, slot.poolKey, sessionFile)
+  }
+  options.setForeground(slot)
+  evictIdleWorkers(options.pool, {
+    foregroundKey: slot.poolKey,
+    maxWorkers: readMaxSessionWorkers(),
+  })
+  return { sessionId, sessionFile }
+}
+
+export async function createNewSessionInPool(
+  options: NewSessionPoolOptions,
+): Promise<{ sessionId: string; sessionFile?: string }> {
+  const reusable = findReusableWorkspaceSlot(options)
+  if (reusable) return runNewSession(reusable, options)
+
+  const capacity = canAcquireNewWorker(options.pool)
+  if (!capacity.ok) throw new Error(capacity.reason)
+
+  const poolKey = nextWorkspacePoolKey(options.pool, options.cwd)
+  const { slot, init } = await forkWorkerForCwd(options.cwd, {
+    poolKey,
+    sessionFile: null,
+  })
+  options.pool.set(poolKey, slot)
+  attachWorkerHandlers(slot, slot.worker, {
+    mainWindow: options.mainWindow,
+    getForegroundPoolKey: options.foregroundPoolKey,
+    onAppEvent: options.onAppEvent,
+    onSlotExit: options.onSlotExit,
+  })
+
+  try {
+    await init
+    return await runNewSession(slot, options)
+  } catch (error) {
+    if (options.pool.get(slot.poolKey) === slot) options.pool.delete(slot.poolKey)
+    await disposeWorkerSlot(slot)
+    throw error
+  }
+}

--- a/src/main/worker-manager.ts
+++ b/src/main/worker-manager.ts
@@ -33,6 +33,7 @@ import { isWslWindowsPath } from '@shared/wsl-path'
 import { getAgentRuntimeConfig, isWslRuntimeActive } from './wsl/runtime-config'
 import { readMaxSessionWorkers } from './worker-pool-config'
 import { configStore } from './config-store'
+import { createNewSessionInPool } from './worker-manager-new-session'
 import { readSessionMetaFromFile } from './session-file-meta'
 import {
   applySettledRunToSessionLeafOverride,
@@ -451,18 +452,14 @@ export class WorkerManager {
    * Abort agent turn on the session's existing worker only.
    * Never ensure/create a worker just to abort (would race F1 / wrong cwd).
    */
-  async abort(sessionFile?: string): Promise<void> {
-    if (sessionFile) {
-      const sk = normalizeSessionKey(sessionFile)
-      const slot = this.pool.get(sk)
-      if (!slot || slot.stopping) {
-        // No live worker for this session — already idle from UI's perspective.
-        return
-      }
-      await this.requestOnSlot(slot, 'abort', { sessionFile: sk })
+  async abort(sessionFile: string): Promise<void> {
+    const sk = normalizeSessionKey(sessionFile)
+    const slot = this.pool.get(sk)
+    if (!slot || slot.stopping) {
+      // No live worker for this session — already idle from UI's perspective.
       return
     }
-    await this.request('abort', {})
+    await this.requestOnSlot(slot, 'abort', { sessionFile: sk })
   }
   async steer(text: string, sessionFile?: string): Promise<void> {
     await this.request('steer', { text, sessionFile })
@@ -487,14 +484,24 @@ export class WorkerManager {
       setSessionLeafOverride(sessionFile, response.leafId as string | null)
     }
   }
-  async newSession(): Promise<{ sessionId: string; sessionFile?: string }> {
-    const r = await this.request('newSession')
-    const sessionId = String(r.sessionId ?? '')
-    const sessionFile = r.sessionFile ? String(r.sessionFile) : undefined
-    if (sessionFile) {
-      await this.remapForegroundSlotToSessionFile(sessionFile)
-    }
-    return { sessionId, sessionFile }
+  async newSession(cwd: string): Promise<{ sessionId: string; sessionFile?: string }> {
+    const run = this.lifecycleChain.then(() =>
+      createNewSessionInPool({
+        cwd,
+        pool: this.pool,
+        mainWindow: this.mainWindow,
+        foregroundPoolKey: () => this.foregroundPoolKey,
+        slotMatchesCurrentRuntime: (slot) => this.slotMatchesCurrentRuntime(slot),
+        setForeground: (slot) => this.setForeground(slot),
+        onAppEvent: (payload) => this.forwardAppEvent(payload),
+        onSlotExit: (slot, code) => this.handleSlotExit(slot, code),
+      }),
+    )
+    this.lifecycleChain = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
   }
 
   /**
@@ -696,9 +703,15 @@ export class WorkerManager {
     const r = await this.request('getCommands')
     return { commands: (r.commands as WorkerCommandInfo[]) || [], hasSession: !!r.hasSession }
   }
-  async getSessionContextPreview(): Promise<WorkerContextPreview> {
-    const r = await this.request('getSessionContextPreview')
-    return (r.preview as WorkerContextPreview) || null
+  async getSessionContextPreview(sessionFile: string): Promise<WorkerContextPreview> {
+    const sk = normalizeSessionKey(sessionFile)
+    if (!sk) return null
+    const slot = this.pool.get(sk)
+    if (!slot || slot.stopping) return null
+    const r = await this.requestOnSlot(slot, 'getSessionContextPreview', { sessionFile: sk })
+    const preview = (r.preview as WorkerContextPreview) || null
+    if (!preview) return null
+    return { ...preview, sessionFile: slot.sessionFile || sk }
   }
   async getSkillsList(): Promise<WorkerSkillInfo[]> {
     const r = await this.request('getSkillsList')

--- a/src/renderer/src/features/composer/composer.tsx
+++ b/src/renderer/src/features/composer/composer.tsx
@@ -289,11 +289,7 @@ export function Composer() {
       return composerTurnActive({
         historySessionFile: s.historySessionFile,
         workerLiveSnapshot: s.workerLiveSnapshot,
-        runState: s.runState,
-        streamingAssistantId: s.streamingAssistantId,
-        optimisticPendingUserText: s.optimisticPendingUserText,
         sessionRuntimeRunning: s.sessionRuntimeRunning,
-        agentTurnBootstrapping: s.agentTurnBootstrapping,
       })
     }
     // Initial pull only when this view might already be running (avoid racing open-session idle reset)

--- a/src/renderer/src/features/composer/use-composer-metrics-context-isolation.test.tsx
+++ b/src/renderer/src/features/composer/use-composer-metrics-context-isolation.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ipcClient } from '@renderer/lib/ipc-client'
+import { useUIStore } from '@renderer/stores/ui-store'
+import { useComposerMetrics } from './use-composer-metrics'
+
+vi.mock('@renderer/lib/ipc-client', () => ({
+  ipcClient: { invoke: vi.fn(() => Promise.resolve({})) },
+}))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('useComposerMetrics context isolation', () => {
+  beforeEach(() => {
+    vi.mocked(ipcClient.invoke).mockReset()
+    useUIStore.setState({
+      currentWorkspace: '/workspace',
+      currentSessionId: 'session-a',
+      historySessionFile: '/sessions/a.jsonl',
+      historyLoading: false,
+      runState: {
+        status: 'idle',
+        model: undefined,
+        usage: undefined,
+        toolCount: 0,
+        errorCount: 0,
+      },
+      streamingAssistantId: null,
+      timelineItems: [],
+    })
+  })
+
+  it('requests context for the visible session file', async () => {
+    vi.mocked(ipcClient.invoke).mockResolvedValue({
+      preview: {
+        sessionFile: '/sessions/a.jsonl',
+        messageCount: 1,
+        estimatedChars: 10,
+      },
+    })
+
+    renderHook(() => useComposerMetrics())
+
+    await waitFor(() => {
+      expect(ipcClient.invoke).toHaveBeenCalledWith('context.preview', {
+        sessionFile: '/sessions/a.jsonl',
+        workspaceId: '/workspace',
+      })
+    })
+  })
+
+  it('ignores a late response from the previous session', async () => {
+    const first = deferred<{
+      preview: { sessionFile: string; messageCount: number; estimatedChars: number }
+    }>()
+    vi.mocked(ipcClient.invoke).mockImplementation((channel, request) => {
+      if (channel !== 'context.preview') return Promise.resolve({})
+      const sessionFile = (request as { sessionFile?: string } | undefined)?.sessionFile
+      if (sessionFile === '/sessions/a.jsonl') return first.promise
+      return Promise.resolve({
+        preview: {
+          sessionFile: '/sessions/b.jsonl',
+          messageCount: 2,
+          estimatedChars: 20,
+        },
+      })
+    })
+    const { result } = renderHook(() => useComposerMetrics())
+
+    act(() => {
+      useUIStore.setState({
+        currentSessionId: 'session-b',
+        historySessionFile: '/sessions/b.jsonl',
+      })
+    })
+    await waitFor(() => expect(result.current.contextPreview?.estimatedChars).toBe(20))
+
+    await act(async () => {
+      first.resolve({
+        preview: {
+          sessionFile: '/sessions/a.jsonl',
+          messageCount: 1,
+          estimatedChars: 10,
+        },
+      })
+      await first.promise
+    })
+
+    expect(result.current.contextPreview?.estimatedChars).toBe(20)
+  })
+})

--- a/src/renderer/src/features/composer/use-composer-metrics.ts
+++ b/src/renderer/src/features/composer/use-composer-metrics.ts
@@ -3,23 +3,14 @@ import { ipcClient } from '@renderer/lib/ipc-client'
 import { useUIStore } from '@renderer/stores/ui-store'
 import { formatTokens, estTokensFromChars } from '@renderer/lib/format-tokens'
 import type { ContextRoleSlice } from '@renderer/features/run/context-donut'
-
-export type ContextPreview = {
-  messageCount: number
-  estimatedChars: number
-  roleBreakdown?: ContextRoleSlice[]
-}
-
-const RUNNING_CONTEXT_REFRESH_MS = 8000
+import { useSessionContextPreview } from '@renderer/features/context/use-session-context-preview'
 
 export function useComposerMetrics(options?: { enabled?: boolean }) {
   const metricsEnabled = options?.enabled !== false
   const workspace = useUIStore((s) => s.currentWorkspace)
-  const currentSessionId = useUIStore((s) => s.currentSessionId)
   const model = useUIStore((s) => s.runState.model)
   const usage = useUIStore((s) => s.runState.usage)
   const isRunning = useUIStore((s) => s.runState.status === 'running')
-  const historyLoading = useUIStore((s) => s.historyLoading)
   const streamingId = useUIStore((s) => s.streamingAssistantId)
   const streamLen = useUIStore((s) => {
     if (!s.streamingAssistantId) return 0
@@ -27,55 +18,18 @@ export function useComposerMetrics(options?: { enabled?: boolean }) {
     return item?.text?.length ?? 0
   })
 
-  const [contextPreview, setContextPreview] = useState<ContextPreview | null>(null)
+  const { preview: rawContextPreview } = useSessionContextPreview({ enabled: metricsEnabled })
+  const contextPreview = rawContextPreview
+    ? {
+        messageCount: rawContextPreview.messageCount,
+        estimatedChars: rawContextPreview.estimatedChars,
+        roleBreakdown: rawContextPreview.roleBreakdown as ContextRoleSlice[],
+      }
+    : null
   const [contextWindow, setContextWindow] = useState<number | null>(null)
   const [tps, setTps] = useState<number | null>(null)
 
   const streamRef = useRef({ id: null as string | null, start: 0, lastLen: 0, lastAt: 0 })
-
-  useEffect(() => {
-    if (!metricsEnabled || !workspace) {
-      setContextPreview(null)
-      return
-    }
-    let cancelled = false
-    const load = () => {
-      if (historyLoading) return
-      if (typeof document !== 'undefined' && document.hidden) return
-      ipcClient
-        .invoke('context.preview')
-        .then((r) => {
-          if (!cancelled && r?.preview) {
-            const rawBreakdown = Array.isArray(r.preview.roleBreakdown)
-              ? (r.preview.roleBreakdown as ContextRoleSlice[])
-              : undefined
-            setContextPreview({
-              messageCount: r.preview.messageCount ?? 0,
-              estimatedChars: r.preview.estimatedChars ?? 0,
-              roleBreakdown: rawBreakdown,
-            })
-          }
-        })
-        .catch(() => {})
-    }
-    // One-shot on session / history settle; poll only while the turn is running and visible.
-    load()
-    if (!isRunning) {
-      return () => {
-        cancelled = true
-      }
-    }
-    const intervalId = window.setInterval(load, RUNNING_CONTEXT_REFRESH_MS)
-    const onVisibility = () => {
-      if (!document.hidden) load()
-    }
-    document.addEventListener('visibilitychange', onVisibility)
-    return () => {
-      cancelled = true
-      window.clearInterval(intervalId)
-      document.removeEventListener('visibilitychange', onVisibility)
-    }
-  }, [metricsEnabled, workspace, currentSessionId, historyLoading, isRunning])
 
   useEffect(() => {
     if (!metricsEnabled || !workspace || !model) {

--- a/src/renderer/src/features/composer/use-composer-send.ts
+++ b/src/renderer/src/features/composer/use-composer-send.ts
@@ -54,11 +54,7 @@ export function useComposerSend(opts: {
       const running = composerTurnActive({
         historySessionFile: store.historySessionFile,
         workerLiveSnapshot: store.workerLiveSnapshot,
-        runState: store.runState,
-        streamingAssistantId: store.streamingAssistantId,
-        optimisticPendingUserText: store.optimisticPendingUserText,
         sessionRuntimeRunning: store.sessionRuntimeRunning,
-        agentTurnBootstrapping: store.agentTurnBootstrapping,
       })
       if (displayText.trim()) inputHistory.recordSent(displayText.trim())
       const { hideAllDelayedTooltips } = await import('./delayed-tooltip')
@@ -69,7 +65,9 @@ export function useComposerSend(opts: {
       editorRef.current?.focus()
       const pendingNew = store.pendingNewSessionPlaceholder
       const homeMode = !store.currentSessionId && store.timelineItems.length === 0
-      const { appendOptimisticOutgoingMessage } = await import('@renderer/lib/optimistic-send')
+      const { appendOptimisticOutgoingMessage, bindOptimisticOutgoingToSession } =
+        await import('@renderer/lib/optimistic-send')
+      let optimisticToken: ReturnType<typeof appendOptimisticOutgoingMessage> = null
       const promptPayload = () => ({
         sessionId: '',
         sessionFile: useUIStore.getState().historySessionFile ?? undefined,
@@ -84,17 +82,33 @@ export function useComposerSend(opts: {
       try {
         const { afterPromptSent } = await import('@renderer/lib/after-prompt-sent')
         if (!running && draft) {
-          appendOptimisticOutgoingMessage(pendMsg, { bootstrap: true, attachments: atts, segments })
+          optimisticToken = appendOptimisticOutgoingMessage(pendMsg, {
+            bootstrap: true,
+            attachments: atts,
+            segments,
+          })
           const { finalizeEphemeralSandboxOnFirstSend } = await import('@renderer/lib/ephemeral-sandbox')
           await finalizeEphemeralSandboxOnFirstSend(pendMsg)
+          bindOptimisticOutgoingToSession(
+            optimisticToken,
+            useUIStore.getState().historySessionFile,
+          )
           const bind = await sendPrompt()
           await afterPromptSent(bind)
           return
         }
         if (!running && (homeMode || pendingNew) && store.currentWorkspace) {
-          appendOptimisticOutgoingMessage(pendMsg, { bootstrap: true, attachments: atts, segments })
+          optimisticToken = appendOptimisticOutgoingMessage(pendMsg, {
+            bootstrap: true,
+            attachments: atts,
+            segments,
+          })
           const { materializePendingNewSession } = await import('@renderer/lib/new-session')
           await materializePendingNewSession(store.currentWorkspace, pendMsg)
+          bindOptimisticOutgoingToSession(
+            optimisticToken,
+            useUIStore.getState().historySessionFile,
+          )
           const bind = await sendPrompt()
           await afterPromptSent(bind)
           return
@@ -110,14 +124,15 @@ export function useComposerSend(opts: {
           }
           return
         }
-        appendOptimisticOutgoingMessage(pendMsg, { attachments: atts, segments })
+        optimisticToken = appendOptimisticOutgoingMessage(pendMsg, { attachments: atts, segments })
         const bind = await sendPrompt()
         await afterPromptSent(bind)
       } catch (e) {
         console.error('Send failed:', e)
         const { clearOptimisticOutgoing } = await import('@renderer/lib/optimistic-send')
-        clearOptimisticOutgoing()
-        useUIStore.getState().setRunState({ status: 'idle' })
+        if (clearOptimisticOutgoing(optimisticToken)) {
+          useUIStore.getState().setRunState({ status: 'idle' })
+        }
         toast.error(t('composer:toast.sendFailed'))
       }
     },
@@ -167,7 +182,7 @@ export function useComposerSend(opts: {
   )
 
   const handleAbort = useCallback(() => {
-    if (isComposerAbortCooldown()) return
+    if (isComposerAbortCooldown(useUIStore.getState().historySessionFile)) return
     const el = editorRef.current
     const currentText = el ? serializeRichInput(el).displayText : text
     void runComposerAbort(currentText)

--- a/src/renderer/src/features/context/context-panel.tsx
+++ b/src/renderer/src/features/context/context-panel.tsx
@@ -5,21 +5,7 @@ import { useUIStore } from '@renderer/stores/ui-store'
 import { RefreshCw, ChevronDown, ChevronRight, Layers, MessageSquare } from '@renderer/components/icons'
 import { cn } from '@renderer/lib/utils'
 import { formatTokens, estTokensFromChars } from '@renderer/lib/format-tokens'
-
-type Segment = {
-  index: number
-  role: string
-  chars: number
-  preview: string
-  label?: string
-}
-
-type ContextPreview = {
-  messageCount: number
-  estimatedChars: number
-  snippets?: string[]
-  segments?: Segment[]
-}
+import { useSessionContextPreview } from './use-session-context-preview'
 
 const ROLE_STYLE: Record<string, { bar: string; badge: string; labelKey: string }> = {
   user: { bar: 'bg-blue-500/70', badge: 'bg-blue-500/15 text-blue-700 dark:text-blue-300', labelKey: 'context:userLabel' },
@@ -44,26 +30,13 @@ export function ContextPanel() {
   const { t } = useTranslation()
   const workspace = useUIStore((s) => s.currentWorkspace)
   const model = useUIStore((s) => s.runState.model)
-  const [preview, setPreview] = useState<ContextPreview | null>(null)
+  const { preview, loading, refresh } = useSessionContextPreview()
   const [contextWindow, setContextWindow] = useState<number | null>(null)
-  const [loading, setLoading] = useState(false)
   const [expanded, setExpanded] = useState<Set<number>>(() => new Set())
 
-  const load = () => {
-    if (!workspace) return
-    setLoading(true)
-    ipcClient
-      .invoke('context.preview')
-      .then((r) => setPreview(r?.preview || null))
-      .catch(() => setPreview(null))
-      .finally(() => setLoading(false))
-  }
-
   useEffect(() => {
-    // Context panel is only mounted while active; one-shot load on open / workspace change.
-    // Manual refresh remains available via the panel button; no idle polling.
-    load()
-  }, [workspace])
+    setExpanded(new Set())
+  }, [preview?.sessionFile])
 
   useEffect(() => {
     if (!workspace || !model) {
@@ -115,7 +88,7 @@ export function ContextPanel() {
           <Layers className="h-4 w-4 text-foreground-secondary/70" />
           <span className="text-[13px] font-semibold text-foreground">{t('context:title')}</span>
         </div>
-        <button type="button" onClick={load} className="chrome-icon-btn rounded-md p-1.5" title={t('context:refresh')}>
+        <button type="button" onClick={() => void refresh()} className="chrome-icon-btn rounded-md p-1.5" title={t('context:refresh')}>
           <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
         </button>
       </div>

--- a/src/renderer/src/features/context/use-session-context-preview.ts
+++ b/src/renderer/src/features/context/use-session-context-preview.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { SessionContextPreview } from '@shared/session-context-preview'
+import { ipcClient } from '@renderer/lib/ipc-client'
+import { sessionFilesEqual } from '@renderer/lib/session-file-key'
+import { useUIStore } from '@renderer/stores/ui-store'
+
+const RUNNING_CONTEXT_REFRESH_MS = 8000
+
+export function useSessionContextPreview(options?: { enabled?: boolean }) {
+  const enabled = options?.enabled !== false
+  const workspace = useUIStore((state) => state.currentWorkspace)
+  const sessionFile = useUIStore((state) => state.historySessionFile)
+  const historyLoading = useUIStore((state) => state.historyLoading)
+  const isRunning = useUIStore((state) => state.runState.status === 'running')
+  const [preview, setPreview] = useState<SessionContextPreview | null>(null)
+  const [loading, setLoading] = useState(false)
+  const requestIdRef = useRef(0)
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!enabled || !workspace || !sessionFile || historyLoading) return
+    if (typeof document !== 'undefined' && document.hidden) return
+    const requestId = ++requestIdRef.current
+    const requestedFile = sessionFile
+    setLoading(true)
+    try {
+      const response = await ipcClient.invoke('context.preview', {
+        sessionFile: requestedFile,
+        workspaceId: workspace,
+      })
+      if (requestId !== requestIdRef.current) return
+      const next = (response?.preview || null) as SessionContextPreview | null
+      setPreview(next && sessionFilesEqual(next.sessionFile, requestedFile) ? next : null)
+    } catch {
+      if (requestId === requestIdRef.current) setPreview(null)
+    } finally {
+      if (requestId === requestIdRef.current) setLoading(false)
+    }
+  }, [enabled, workspace, sessionFile, historyLoading])
+
+  useEffect(() => {
+    requestIdRef.current += 1
+    setPreview(null)
+    setLoading(false)
+    return () => {
+      requestIdRef.current += 1
+    }
+  }, [enabled, workspace, sessionFile, historyLoading])
+
+  useEffect(() => {
+    if (!enabled || !workspace || !sessionFile || historyLoading) return
+    void refresh()
+    const intervalId = isRunning
+      ? window.setInterval(() => void refresh(), RUNNING_CONTEXT_REFRESH_MS)
+      : null
+    const onVisibility = () => {
+      if (!document.hidden) void refresh()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => {
+      if (intervalId != null) window.clearInterval(intervalId)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [enabled, workspace, sessionFile, historyLoading, isRunning, refresh])
+
+  return { preview, loading, refresh }
+}

--- a/src/renderer/src/lib/__tests__/optimistic-user-switch-survival.test.ts
+++ b/src/renderer/src/lib/__tests__/optimistic-user-switch-survival.test.ts
@@ -160,7 +160,6 @@ describe('just-sent user message survives session switch during streaming', () =
       runState: { status: 'idle', toolCount: 0, errorCount: 0 },
       workerLiveSnapshot: { sessionId: 'session-a', sessionFile: sessionA, status: 'idle' },
       fileChanges: [],
-      ignoreQueueSyncUntil: 0,
     })
   })
 

--- a/src/renderer/src/lib/__tests__/session-chrome.test.ts
+++ b/src/renderer/src/lib/__tests__/session-chrome.test.ts
@@ -79,7 +79,7 @@ describe('selectSessionChrome', () => {
   })
 
   it('maps abort hold to stopping even after local idle clear', () => {
-    markAbortUiHold(5000)
+    markAbortUiHold('/a.jsonl', 5000)
     const view = selectSessionChrome(
       base({
         runState: { status: 'idle' },
@@ -91,11 +91,22 @@ describe('selectSessionChrome', () => {
     expect(view.showSpinner).toBe(true)
   })
 
+  it('does not project another session abort hold into the visible session', () => {
+    markAbortUiHold('/a.jsonl', 5000)
+
+    const view = selectSessionChrome(base({ historySessionFile: '/b.jsonl' }))
+
+    expect(view.phase).toBe('idle')
+    expect(view.canStop).toBe(false)
+    expect(view.showSpinner).toBe(false)
+  })
+
   it('maps streaming assistant to streaming phase', () => {
     const view = selectSessionChrome(
       base({
         streamingAssistantId: 'a1',
         runState: { status: 'running', activeRunId: 'r1' },
+        sessionRuntimeRunning: { '/a.jsonl': true },
       }),
     )
     expect(view.phase).toBe('streaming')
@@ -108,6 +119,7 @@ describe('selectSessionChrome', () => {
         agentTurnBootstrapping: true,
         optimisticPendingUserText: 'hi',
         runState: { status: 'running' },
+        sessionRuntimeRunning: { '/a.jsonl': true },
       }),
     )
     expect(view.phase).toBe('starting')

--- a/src/renderer/src/lib/__tests__/session-shell-stream-switch-race.test.ts
+++ b/src/renderer/src/lib/__tests__/session-shell-stream-switch-race.test.ts
@@ -95,7 +95,6 @@ describe('session shell stream switch race', () => {
         status: 'running',
       },
       fileChanges: [],
-      ignoreQueueSyncUntil: 0,
     })
   })
 

--- a/src/renderer/src/lib/__tests__/session-shell.test.ts
+++ b/src/renderer/src/lib/__tests__/session-shell.test.ts
@@ -171,14 +171,11 @@ describe('session-shell', () => {
     expect(getSessionView('/tmp/run.jsonl')).not.toBeNull()
   })
 
-  it('composerTurnActive ignores residual runState (Phase A lock)', () => {
+  it('composerTurnActive ignores a running state owned by another session', () => {
     expect(
       composerTurnActive({
         historySessionFile: '/tmp/b.jsonl',
         workerLiveSnapshot: { sessionId: 'b', sessionFile: '/tmp/b.jsonl', status: 'idle' },
-        runState: { status: 'running' },
-        streamingAssistantId: null,
-        optimisticPendingUserText: null,
         sessionRuntimeRunning: { '/tmp/a.jsonl': true },
       }),
     ).toBe(false)

--- a/src/renderer/src/lib/__tests__/session-worker-sync.test.ts
+++ b/src/renderer/src/lib/__tests__/session-worker-sync.test.ts
@@ -66,9 +66,6 @@ describe('session-worker-sync', () => {
       composerTurnActive({
         historySessionFile: '/a.jsonl',
         workerLiveSnapshot: { sessionId: 's1', sessionFile: '/a.jsonl', status: 'running' },
-        runState: { status: 'running' },
-        streamingAssistantId: null,
-        optimisticPendingUserText: null,
       }),
     ).toBe(true)
 
@@ -76,9 +73,6 @@ describe('session-worker-sync', () => {
       composerTurnActive({
         historySessionFile: '/b.jsonl',
         workerLiveSnapshot: { sessionId: 's1', sessionFile: '/a.jsonl', status: 'running' },
-        runState: { status: 'running' },
-        streamingAssistantId: null,
-        optimisticPendingUserText: null,
         sessionRuntimeRunning: { '/a.jsonl': true },
       }),
     ).toBe(false)
@@ -87,9 +81,6 @@ describe('session-worker-sync', () => {
       composerTurnActive({
         historySessionFile: '/b.jsonl',
         workerLiveSnapshot: { sessionId: 's2', sessionFile: '/b.jsonl', status: 'idle' },
-        runState: { status: 'idle' },
-        streamingAssistantId: null,
-        optimisticPendingUserText: null,
         sessionRuntimeRunning: { '/b.jsonl': true },
       }),
     ).toBe(true)
@@ -98,45 +89,9 @@ describe('session-worker-sync', () => {
       composerTurnActive({
         historySessionFile: '/a.jsonl',
         workerLiveSnapshot: { sessionId: 's1', sessionFile: '/a.jsonl', status: 'idle' },
-        runState: { status: 'idle' },
-        streamingAssistantId: null,
-        optimisticPendingUserText: null,
       }),
     ).toBe(false)
 
-    // residual global runState.running after switch to idle session — NEVER trust alone
-    expect(
-      composerTurnActive({
-        historySessionFile: '/b.jsonl',
-        workerLiveSnapshot: { sessionId: 's2', sessionFile: '/b.jsonl', status: 'idle' },
-        runState: { status: 'running' },
-        streamingAssistantId: null,
-        optimisticPendingUserText: null,
-        sessionRuntimeRunning: { '/a.jsonl': true },
-      }),
-    ).toBe(false)
-
-    // residual runState + unscoped worker snap running — still false for idle view B
-    expect(
-      composerTurnActive({
-        historySessionFile: '/b.jsonl',
-        workerLiveSnapshot: { sessionId: null, sessionFile: null, status: 'running' },
-        runState: { status: 'running' },
-        streamingAssistantId: null,
-        optimisticPendingUserText: null,
-      }),
-    ).toBe(false)
-
-    // local streaming markers still count for current view
-    expect(
-      composerTurnActive({
-        historySessionFile: '/b.jsonl',
-        workerLiveSnapshot: { sessionId: 's2', sessionFile: '/b.jsonl', status: 'idle' },
-        runState: { status: 'idle' },
-        streamingAssistantId: 'opt-asst-2',
-        optimisticPendingUserText: null,
-      }),
-    ).toBe(true)
   })
 
   it('fetchWorkerLiveSnapshot does not mark requested idle session as running from foreign reply', async () => {
@@ -161,10 +116,13 @@ describe('session-worker-sync', () => {
   })
 
   it('keeps worker snapshot idle during abort hold', () => {
-    markAbortUiHold()
+    markAbortUiHold('/a.jsonl')
     expect(
       normalizeWorkerLiveSnapshotForView({ sessionId: 's1', sessionFile: '/a.jsonl', status: 'running' }).status,
     ).toBe('idle')
+    expect(
+      normalizeWorkerLiveSnapshotForView({ sessionId: 's2', sessionFile: '/b.jsonl', status: 'running' }).status,
+    ).toBe('running')
   })
 
   it('syncs runState to running only when view matches worker file', () => {
@@ -205,4 +163,44 @@ describe('session-worker-sync', () => {
     expect(snap).toEqual({ sessionId: null, sessionFile: '/b.jsonl', status: 'idle' })
     expect(runStatus).toBeNull()
   })
+
+  it('reconciles stale runtime UI when the bound worker is authoritatively idle', () => {
+    const reconcileSessionRuntimeIdle = vi.fn()
+    applyLiveSnapshotToView(
+      '/b.jsonl',
+      { sessionId: 's2', sessionFile: '/b.jsonl', status: 'idle' },
+      {
+        historySessionFile: '/b.jsonl',
+        runState: { status: 'running', toolCount: 0, errorCount: 0 },
+        setWorkerLiveSnapshot: vi.fn(),
+        setRunState: vi.fn(),
+        reconcileSessionRuntimeIdle,
+      } as Parameters<typeof applyLiveSnapshotToView>[2],
+    )
+
+    expect(reconcileSessionRuntimeIdle).toHaveBeenCalledWith('/b.jsonl')
+  })
+
+  it('ignores an idle poll that races ahead of the first run event', () => {
+    const setWorkerLiveSnapshot = vi.fn()
+    const setRunState = vi.fn()
+    const reconcileSessionRuntimeIdle = vi.fn()
+    applyLiveSnapshotToView(
+      '/b.jsonl',
+      { sessionId: 's2', sessionFile: '/b.jsonl', status: 'idle' },
+      {
+        historySessionFile: '/b.jsonl',
+        runState: { status: 'running', toolCount: 0, errorCount: 0 },
+        agentTurnBootstrapping: true,
+        setWorkerLiveSnapshot,
+        setRunState,
+        reconcileSessionRuntimeIdle,
+      },
+    )
+
+    expect(setWorkerLiveSnapshot).not.toHaveBeenCalled()
+    expect(setRunState).not.toHaveBeenCalled()
+    expect(reconcileSessionRuntimeIdle).not.toHaveBeenCalled()
+  })
+
 })

--- a/src/renderer/src/lib/abort-ui-hold.ts
+++ b/src/renderer/src/lib/abort-ui-hold.ts
@@ -1,13 +1,70 @@
-let abortUiHoldUntil = 0
+import { normalizeSessionFileKey } from '@renderer/lib/session-file-key'
+import type { SessionScopedAppEvent } from '@shared/app-event-session'
 
-export function markAbortUiHold(ms = 2800): void {
-  abortUiHoldUntil = Date.now() + ms
+const abortUiHoldUntil = new Map<string, number>()
+const abortQueueIgnoreUntil = new Map<string, number>()
+
+function isSessionTimerActive(
+  timers: Map<string, number>,
+  sessionFile: string | null | undefined,
+): boolean {
+  const key = normalizeSessionFileKey(sessionFile)
+  if (!key) return false
+  const until = timers.get(key) ?? 0
+  if (Date.now() < until) return true
+  timers.delete(key)
+  return false
 }
 
-export function isAbortUiHoldActive(): boolean {
-  return Date.now() < abortUiHoldUntil
+export function markAbortUiHold(sessionFile: string, ms = 2800): void {
+  const key = normalizeSessionFileKey(sessionFile)
+  if (!key) return
+  abortUiHoldUntil.set(key, Date.now() + ms)
 }
 
-export function clearAbortUiHold(): void {
-  abortUiHoldUntil = 0
+export function isAbortUiHoldActive(sessionFile: string | null | undefined): boolean {
+  return isSessionTimerActive(abortUiHoldUntil, sessionFile)
+}
+
+export function clearAbortUiHold(sessionFile?: string): void {
+  const key = normalizeSessionFileKey(sessionFile)
+  if (key) abortUiHoldUntil.delete(key)
+  else abortUiHoldUntil.clear()
+}
+
+export function markAbortQueueIgnore(sessionFile: string, ms = 5000): void {
+  const key = normalizeSessionFileKey(sessionFile)
+  if (!key) return
+  abortQueueIgnoreUntil.set(key, Date.now() + ms)
+}
+
+export function isAbortQueueIgnoreActive(
+  sessionFile: string | null | undefined,
+): boolean {
+  return isSessionTimerActive(abortQueueIgnoreUntil, sessionFile)
+}
+
+export function clearAbortQueueIgnore(sessionFile?: string): void {
+  const key = normalizeSessionFileKey(sessionFile)
+  if (key) abortQueueIgnoreUntil.delete(key)
+  else abortQueueIgnoreUntil.clear()
+}
+
+export function shouldIgnoreAppEventAfterAbort(event: SessionScopedAppEvent): boolean {
+  const sessionFile = event.sessionFile
+  if (!sessionFile) return false
+
+  if (event.type === 'message' && event.role === 'assistant') {
+    return isAbortUiHoldActive(sessionFile)
+  }
+  if (event.type === 'run' && (event.phase === 'started' || event.phase === 'running')) {
+    return (
+      isAbortUiHoldActive(sessionFile) ||
+      (event.phase === 'running' && isAbortQueueIgnoreActive(sessionFile))
+    )
+  }
+  if (event.type === 'queue' && isAbortQueueIgnoreActive(sessionFile)) {
+    return event.steering.length > 0 || event.followUp.length > 0
+  }
+  return false
 }

--- a/src/renderer/src/lib/composer-abort.ts
+++ b/src/renderer/src/lib/composer-abort.ts
@@ -1,13 +1,19 @@
 import { ipcClient } from '@renderer/lib/ipc-client'
 import { applyComposerAbortUi } from '@renderer/lib/composer-queue-restore'
-import { markAbortUiHold } from '@renderer/lib/abort-ui-hold'
+import { isAbortUiHoldActive } from '@renderer/lib/abort-ui-hold'
 import { applyLiveSnapshotToView, composerTurnActive, fetchWorkerLiveSnapshot } from '@renderer/lib/session-worker-sync'
+import { normalizeSessionFileKey, sessionFilesEqual } from '@renderer/lib/session-file-key'
 import { useUIStore } from '@renderer/stores/ui-store'
 
-let abortCooldownUntil = 0
+const abortCooldownUntil = new Map<string, number>()
 
-export function isComposerAbortCooldown(): boolean {
-  return Date.now() < abortCooldownUntil
+export function isComposerAbortCooldown(sessionFile: string | null | undefined): boolean {
+  const key = normalizeSessionFileKey(sessionFile)
+  if (!key) return false
+  const until = abortCooldownUntil.get(key) ?? 0
+  if (Date.now() < until) return true
+  abortCooldownUntil.delete(key)
+  return false
 }
 
 /** 单次 Worker abort（内含 clearQueue）；避免 clearQueue + abort 双 RPC */
@@ -15,28 +21,23 @@ export async function abortAgentTurn(opts?: {
   restoreEditorText?: string
   setEditorText?: (v: string) => void
 }): Promise<void> {
-  if (isComposerAbortCooldown()) return
-  abortCooldownUntil = Date.now() + 700
-
   const store = useUIStore.getState()
   const sessionFile = store.historySessionFile
+  if (!sessionFile) return
+  if (isComposerAbortCooldown(sessionFile)) return
   if (
     !composerTurnActive({
       historySessionFile: sessionFile,
       workerLiveSnapshot: store.workerLiveSnapshot,
-      runState: store.runState,
-      streamingAssistantId: store.streamingAssistantId,
-      optimisticPendingUserText: store.optimisticPendingUserText,
       sessionRuntimeRunning: store.sessionRuntimeRunning,
-      agentTurnBootstrapping: store.agentTurnBootstrapping,
     })
   )
     return
+  abortCooldownUntil.set(normalizeSessionFileKey(sessionFile), Date.now() + 700)
   const queued = [...store.pendingSteering, ...store.pendingFollowUp].filter(Boolean)
   const merged = [queued.join('\n'), (opts?.restoreEditorText || '').trim()].filter(Boolean).join('\n')
 
-  markAbortUiHold()
-  applyComposerAbortUi()
+  applyComposerAbortUi(sessionFile)
 
   if (merged && opts?.setEditorText) opts.setEditorText(merged)
 
@@ -48,20 +49,22 @@ export async function abortAgentTurn(opts?: {
     if (result && (result as { ignored?: boolean }).ignored) {
       console.warn('[composer-abort] prompt.abort ignored by main', result)
       // Force local idle again — user clicked Stop; never leave chrome stuck running.
-      applyComposerAbortUi()
+      if (isAbortUiHoldActive(sessionFile)) applyComposerAbortUi(sessionFile)
     }
   } catch (e) {
     console.error('[composer-abort] prompt.abort failed:', e)
-    applyComposerAbortUi()
+    if (isAbortUiHoldActive(sessionFile)) applyComposerAbortUi(sessionFile)
   }
 
   // Do not re-apply a late getState that might re-light running for this session
   // until the worker has settled; only refresh if still focused here.
   window.setTimeout(() => {
+    if (!isAbortUiHoldActive(sessionFile)) return
     void fetchWorkerLiveSnapshot(useUIStore.getState().currentWorkspace, sessionFile)
       .then((snap) => {
         const s = useUIStore.getState()
-        if (sessionFile && s.historySessionFile !== sessionFile) return
+        if (!sessionFilesEqual(s.historySessionFile, sessionFile)) return
+        if (!isAbortUiHoldActive(sessionFile)) return
         // Abort holds UI idle; ignore streaming=true for a short hold window
         applyLiveSnapshotToView(s.historySessionFile, { ...snap, status: 'idle' }, s)
       })

--- a/src/renderer/src/lib/composer-queue-restore.ts
+++ b/src/renderer/src/lib/composer-queue-restore.ts
@@ -1,17 +1,24 @@
 import { toast } from 'sonner'
 import { ipcClient } from '@renderer/lib/ipc-client'
-import { markAbortUiHold } from '@renderer/lib/abort-ui-hold'
+import { markAbortQueueIgnore, markAbortUiHold } from '@renderer/lib/abort-ui-hold'
+import { markLiveSessionTurnEnded } from '@renderer/lib/live-session-timeline-cache'
 import { markStreamingAssistantIncomplete } from '@renderer/lib/mark-streaming-incomplete'
+import { sessionFilesEqual } from '@renderer/lib/session-file-key'
 import { useUIStore } from '@renderer/stores/ui-store'
 import { flushStreamPendingSync } from '@renderer/stores/ui-store-stream'
 
 /** 对齐 TUI：abort 后立刻让 Composer 可交互（不等 run idle 事件） */
-export function applyComposerAbortUi(): void {
+export function applyComposerAbortUi(sessionFile: string): void {
   const store = useUIStore.getState()
+  markAbortUiHold(sessionFile)
+  markAbortQueueIgnore(sessionFile)
+  store.setSessionRuntimeRunning(sessionFile, false)
+  markLiveSessionTurnEnded(sessionFile, 'idle')
+  if (!sessionFilesEqual(store.historySessionFile, sessionFile)) return
+
   // Always clear focus-session turn UI on explicit abort click.
   // Do not gate on composerTurnActive — that can disagree with the Stop button
   // (e.g. sessionRuntimeRunning set but this helper omitted that field).
-  markAbortUiHold()
   flushStreamPendingSync(useUIStore.getState, useUIStore.setState)
   markStreamingAssistantIncomplete(() => useUIStore.getState(), 'aborted')
   store.setRunState({
@@ -26,7 +33,6 @@ export function applyComposerAbortUi(): void {
     optimisticPendingUserText: null,
   })
   store.clearPendingQueue()
-  store.markAbortQueueIgnore()
   // Keep incomplete assistants; only drop empty non-incomplete bubbles.
   store.pruneEmptyAssistantBubbles()
   const viewFile = store.historySessionFile
@@ -35,7 +41,6 @@ export function applyComposerAbortUi(): void {
     sessionFile: viewFile,
     status: 'idle',
   })
-  if (viewFile) store.setSessionRuntimeRunning(viewFile, false)
   void import('@renderer/lib/extension-ui-tool-sync').then((m) => m.reconcileAllStaleInteractiveToolRows())
 }
 

--- a/src/renderer/src/lib/optimistic-send.ts
+++ b/src/renderer/src/lib/optimistic-send.ts
@@ -1,4 +1,6 @@
 import { useUIStore } from '@renderer/stores/ui-store'
+import { clearAbortQueueIgnore, clearAbortUiHold } from '@renderer/lib/abort-ui-hold'
+import { sessionFilesEqual } from '@renderer/lib/session-file-key'
 import { requestTimelineBottomAnchor } from '@renderer/features/timeline/timeline-bottom-anchor'
 import type { TimelineItem } from '@renderer/stores/ui-store-types'
 
@@ -13,10 +15,33 @@ export type OptimisticSendOpts = {
   segments?: TimelineItem['segments']
 }
 
+export type OptimisticSendToken = {
+  sessionFile: string | null
+  assistantId: string
+}
+
+function markOptimisticSessionRunning(sessionFile: string): void {
+  clearAbortUiHold(sessionFile)
+  clearAbortQueueIgnore(sessionFile)
+  useUIStore.getState().setSessionRuntimeRunning(sessionFile, true)
+}
+
+export function bindOptimisticOutgoingToSession(
+  token: OptimisticSendToken | null,
+  sessionFile: string | null,
+): void {
+  if (!token || !sessionFile) return
+  token.sessionFile = sessionFile
+  markOptimisticSessionRunning(sessionFile)
+}
+
 /** 发送后立即在 Timeline 展示用户消息 + 助手等待占位 */
-export function appendOptimisticOutgoingMessage(text: string, opts?: OptimisticSendOpts): void {
+export function appendOptimisticOutgoingMessage(
+  text: string,
+  opts?: OptimisticSendOpts,
+): OptimisticSendToken | null {
   const trimmed = text.trim()
-  if (!trimmed) return
+  if (!trimmed) return null
   const store = useUIStore.getState()
   const ts = Date.now()
   const userId = `opt-user-${++optSeq}`
@@ -46,16 +71,34 @@ export function appendOptimisticOutgoingMessage(text: string, opts?: OptimisticS
   // Mark this session running immediately so switch-away/back keeps chrome/sidebar alive
   // before the first worker `run` event arrives.
   if (store.historySessionFile) {
-    store.setSessionRuntimeRunning(store.historySessionFile, true)
+    markOptimisticSessionRunning(store.historySessionFile)
   }
   requestTimelineBottomAnchor('message-sent')
   if (store.runState.status !== 'running') {
     store.setRunState({ status: 'running', startTime: ts })
   }
+  return { sessionFile: store.historySessionFile, assistantId }
 }
 
-export function clearOptimisticOutgoing(): void {
+export function clearOptimisticOutgoing(token: OptimisticSendToken | null): boolean {
+  if (!token) return false
   const store = useUIStore.getState()
-  if (!store.optimisticPendingUserText && !store.agentTurnBootstrapping) return
-  useUIStore.setState({ optimisticPendingUserText: null, agentTurnBootstrapping: false })
+  const ownsAssistant = store.streamingAssistantId === token.assistantId
+  const sameView = token.sessionFile
+    ? sessionFilesEqual(store.historySessionFile, token.sessionFile)
+    : ownsAssistant
+  const ownsVisibleTurn = sameView && ownsAssistant
+  const targetFile = token.sessionFile ?? (ownsVisibleTurn ? store.historySessionFile : null)
+
+  if (targetFile && (!sameView || ownsVisibleTurn)) {
+    store.setSessionRuntimeRunning(targetFile, false)
+  }
+  if (!ownsVisibleTurn) return false
+
+  useUIStore.setState({
+    optimisticPendingUserText: null,
+    agentTurnBootstrapping: false,
+    streamingAssistantId: null,
+  })
+  return true
 }

--- a/src/renderer/src/lib/session-chrome.ts
+++ b/src/renderer/src/lib/session-chrome.ts
@@ -82,16 +82,14 @@ export function selectSessionChrome(input: SessionChromeInput): SessionChromeVie
     ? normalizeSessionFileKey(input.historySessionFile) || input.historySessionFile
     : null
   const abortHold =
-    input.abortHoldActive !== undefined ? input.abortHoldActive : isAbortUiHoldActive()
+    input.abortHoldActive !== undefined
+      ? input.abortHoldActive
+      : isAbortUiHoldActive(input.historySessionFile)
 
   const turnActive = composerTurnActive({
     historySessionFile: input.historySessionFile,
     workerLiveSnapshot: input.workerLiveSnapshot,
-    runState: input.runState,
-    streamingAssistantId: input.streamingAssistantId,
-    optimisticPendingUserText: input.optimisticPendingUserText,
     sessionRuntimeRunning: input.sessionRuntimeRunning,
-    agentTurnBootstrapping: input.agentTurnBootstrapping,
   })
 
   // Abort hold always projects stopping (even after local markers cleared by applyComposerAbortUi).

--- a/src/renderer/src/lib/session-fork.ts
+++ b/src/renderer/src/lib/session-fork.ts
@@ -24,11 +24,7 @@ function assertIdleForBranchAction(): boolean {
   const busy = composerTurnActive({
     historySessionFile: store.historySessionFile,
     workerLiveSnapshot: store.workerLiveSnapshot,
-    runState: store.runState,
-    streamingAssistantId: store.streamingAssistantId,
-    optimisticPendingUserText: store.optimisticPendingUserText,
     sessionRuntimeRunning: store.sessionRuntimeRunning,
-    agentTurnBootstrapping: store.agentTurnBootstrapping,
   })
   if (busy) {
     toast.warning(i18n.t('composer:toast.sessionBusyBranch', {

--- a/src/renderer/src/lib/session-shell.ts
+++ b/src/renderer/src/lib/session-shell.ts
@@ -221,12 +221,13 @@ export function bindViewToUiStore(view: SessionView): void {
     live?.streamingAssistantId != null ||
     live?.optimisticPendingUserText != null ||
     live?.agentTurnBootstrapping === true
+  const terminalLive = live != null && !liveRunning
 
   // Prefer the strongest running signal: shell view, runtime map, or live cache.
   const effectiveRunUI: SessionRunUI =
-    view.runUI === 'failed'
+    view.runUI === 'failed' || live?.runState.status === 'failed'
       ? 'failed'
-      : view.runUI === 'running' || runtimeRunning || liveRunning
+      : (view.runUI === 'running' && !terminalLive) || runtimeRunning || liveRunning
         ? 'running'
         : 'idle'
 
@@ -242,13 +243,15 @@ export function bindViewToUiStore(view: SessionView): void {
     live && view.streamingAssistantId === live.streamingAssistantId
       ? live.timelineItems
       : view.items
-  const streamingAssistantId = resolveMergedStreamingAssistantId(
-    view.items,
-    streamCandidateItems,
-    view.streamingAssistantId,
-  )
-  const optimisticPendingUserText = view.optimisticPendingUserText
-  const agentTurnBootstrapping = view.agentTurnBootstrapping
+  const streamingAssistantId = terminalLive
+    ? null
+    : resolveMergedStreamingAssistantId(
+        view.items,
+        streamCandidateItems,
+        view.streamingAssistantId,
+      )
+  const optimisticPendingUserText = terminalLive ? null : view.optimisticPendingUserText
+  const agentTurnBootstrapping = terminalLive ? false : view.agentTurnBootstrapping
 
   useUIStore.setState({
     currentSessionId: view.sessionId,
@@ -355,6 +358,7 @@ export function focusSessionSync(sessionId: string, sessionFile: string): {
       live?.streamingAssistantId != null ||
       live?.optimisticPendingUserText != null ||
       live?.agentTurnBootstrapping === true
+    const terminalLive = live != null && !liveRunning
     const remixedItems =
       view.items.length > 0 ? mergeLiveIntoItems(sessionKey, view.items) : view.items
     const remixedStreamingAssistantId = resolveMergedStreamingAssistantId(
@@ -362,7 +366,7 @@ export function focusSessionSync(sessionId: string, sessionFile: string): {
       live?.timelineItems ?? view.items,
       live ? live.streamingAssistantId : view.streamingAssistantId,
     )
-    if (runtimeRunning || liveRunning || view.runUI === 'running') {
+    if (runtimeRunning || liveRunning || (view.runUI === 'running' && !terminalLive)) {
       view = {
         ...view,
         items: remixedItems,
@@ -376,19 +380,24 @@ export function focusSessionSync(sessionId: string, sessionFile: string): {
           : view.agentTurnBootstrapping,
       }
     } else {
-      const resolved = resolveRunUI(sessionKey, {
-        runtime,
-        streamingAssistantId: remixedStreamingAssistantId,
-        optimisticPendingUserText: view.optimisticPendingUserText,
-        agentTurnBootstrapping: view.agentTurnBootstrapping,
-        workerSessionFile: sessionKey,
-        workerStatus: 'idle',
-      })
+      const resolved =
+        live?.runState.status === 'failed'
+          ? 'failed'
+          : resolveRunUI(sessionKey, {
+              runtime,
+              streamingAssistantId: remixedStreamingAssistantId,
+              optimisticPendingUserText: terminalLive ? null : view.optimisticPendingUserText,
+              agentTurnBootstrapping: terminalLive ? false : view.agentTurnBootstrapping,
+              workerSessionFile: sessionKey,
+              workerStatus: 'idle',
+            })
       view = {
         ...view,
         items: remixedItems,
         runUI: resolved,
         streamingAssistantId: remixedStreamingAssistantId,
+        optimisticPendingUserText: terminalLive ? null : view.optimisticPendingUserText,
+        agentTurnBootstrapping: terminalLive ? false : view.agentTurnBootstrapping,
       }
     }
     views.set(sessionKey, view)
@@ -572,6 +581,7 @@ export async function hydrateSessionView(
       live?.streamingAssistantId != null ||
       live?.optimisticPendingUserText != null ||
       live?.agentTurnBootstrapping === true
+    const priorRunningWithoutTerminalLive = priorRunUI === 'running' && !live
 
     const streamCandidateItems = focusedState
       ? focusedState.timelineItems
@@ -606,13 +616,20 @@ export async function hydrateSessionView(
       agentTurnBootstrapping,
       workerSessionFile: sessionKey,
       workerStatus:
-        runtimeSaysRunning || liveSaysRunning || priorRunUI === 'running' ? 'running' : 'idle',
+        live?.runState.status === 'failed'
+          ? 'failed'
+          : runtimeSaysRunning || liveSaysRunning || priorRunningWithoutTerminalLive
+            ? 'running'
+            : 'idle',
     })
     // Never demote a still-running session to idle just because disk hydrate lacks markers.
     const finalRunUI: SessionRunUI =
       runUI === 'failed'
         ? 'failed'
-        : runUI === 'running' || priorRunUI === 'running' || runtimeSaysRunning || liveSaysRunning
+        : runUI === 'running' ||
+            priorRunningWithoutTerminalLive ||
+            runtimeSaysRunning ||
+            liveSaysRunning
           ? 'running'
           : 'idle'
 

--- a/src/renderer/src/lib/session-worker-sync.ts
+++ b/src/renderer/src/lib/session-worker-sync.ts
@@ -114,20 +114,20 @@ export function canAbortWorkerTurn(
  * Multi-session authority (in order):
  * 1. sessionRuntimeRunning[view]  — set from AppEvents scoped by sessionFile
  * 2. workerLiveSnapshot bound to view && running
- * 3. local streaming markers (optimistic / streamingAssistantId) when worker is not foreign
+ *
+ * Local optimistic markers are display data, not a session identity. They must not
+ * authorize Stop after a view switch until one of the session-scoped signals above
+ * confirms that the visible worker is running.
  *
  * NEVER trust global runState.status alone — residual after switch caused flaky chrome/composer.
  */
 export function composerTurnActive(input: {
   historySessionFile: string | null
   workerLiveSnapshot: WorkerLiveSnapshot
-  runState: { status: string }
-  streamingAssistantId: string | null
-  optimisticPendingUserText: string | null
   sessionRuntimeRunning?: Record<string, boolean> | null
-  agentTurnBootstrapping?: boolean
 }): boolean {
   const viewFile = input.historySessionFile
+  if (!viewFile) return false
   if (runtimeRunningForSession(viewFile, input.sessionRuntimeRunning)) return true
 
   const workerFile = input.workerLiveSnapshot.sessionFile
@@ -135,21 +135,6 @@ export function composerTurnActive(input: {
   const workerBoundHere = sessionFilesEqual(viewFile, workerFile)
 
   if (workerBoundHere && workerRunning) return true
-
-  const localStreaming =
-    input.streamingAssistantId != null ||
-    input.optimisticPendingUserText != null ||
-    input.agentTurnBootstrapping === true
-
-  if (localStreaming) {
-    // Foreign worker snap must not keep Stop lit for an idle view with cleared markers —
-    // but if markers exist they belong to the current view (openSession clears on switch).
-    if (viewFile && workerFile && !sessionFilesEqual(viewFile, workerFile) && workerRunning) {
-      // Local markers + foreign running worker: still show active if markers present
-      // (user just switched mid-send onto a session that has optimistic UI). Keep true.
-    }
-    return true
-  }
 
   // Explicitly ignore residual runState.status === 'running'
   return false
@@ -167,7 +152,7 @@ export function syncViewRunStateFromWorkerSnapshot(
   }) => void,
 ): void {
   if (!isViewingWorkerBoundSession(viewSessionFile, snap.sessionFile)) return
-  if (isAbortUiHoldActive()) {
+  if (isAbortUiHoldActive(viewSessionFile)) {
     setRunState({
       status: 'idle',
       activeTool: undefined,
@@ -188,16 +173,21 @@ export function syncViewRunStateFromWorkerSnapshot(
   }
 }
 
-export function normalizeWorkerLiveSnapshotForView(snap: WorkerLiveSnapshot): WorkerLiveSnapshot {
-  if (!isAbortUiHoldActive()) return snap
+export function normalizeWorkerLiveSnapshotForView(
+  snap: WorkerLiveSnapshot,
+  viewSessionFile: string | null | undefined = snap.sessionFile,
+): WorkerLiveSnapshot {
+  if (!isAbortUiHoldActive(viewSessionFile)) return snap
   return { ...snap, status: 'idle' }
 }
 
 type ViewStore = {
   historySessionFile: string | null
   runState: RunState
+  agentTurnBootstrapping?: boolean
   setWorkerLiveSnapshot: (snap: WorkerLiveSnapshot) => void
   setRunState: (patch: Partial<RunState>) => void
+  reconcileSessionRuntimeIdle?: (sessionFile: string) => void
 }
 
 /**
@@ -209,7 +199,7 @@ export function applyLiveSnapshotToView(
   snap: WorkerLiveSnapshot,
   store: ViewStore,
 ): void {
-  const normalized = normalizeWorkerLiveSnapshotForView(snap)
+  const normalized = normalizeWorkerLiveSnapshotForView(snap, viewSessionFile)
 
   if (viewSessionFile) {
     if (normalized.sessionFile && !sessionFilesEqual(normalized.sessionFile, viewSessionFile)) {
@@ -231,6 +221,19 @@ export function applyLiveSnapshotToView(
     sessionFile: normalized.sessionFile ?? viewSessionFile ?? null,
   }
 
+  // A first-send poll can race ahead of the worker's run.started event. Ignore
+  // that idle sample completely; once a run id exists, a later idle is terminal.
+  if (
+    boundSnap.status === 'idle' &&
+    store.agentTurnBootstrapping === true &&
+    !store.runState.activeRunId
+  ) {
+    return
+  }
+
+  if (boundSnap.status !== 'running' && viewSessionFile) {
+    store.reconcileSessionRuntimeIdle?.(viewSessionFile)
+  }
   store.setWorkerLiveSnapshot(boundSnap)
   syncViewRunStateFromWorkerSnapshot(viewSessionFile, boundSnap, (p) => store.setRunState(p))
 }

--- a/src/renderer/src/stores/__tests__/apply-app-event-background.test.ts
+++ b/src/renderer/src/stores/__tests__/apply-app-event-background.test.ts
@@ -36,7 +36,6 @@ function makeApi(): StoreApi {
     fileChanges: [],
     optimisticPendingUserText: null,
     agentTurnBootstrapping: false,
-    ignoreQueueSyncUntil: 0,
     pendingSteering: [] as string[],
     pendingFollowUp: [] as string[],
     rightPanelCatalog: [],

--- a/src/renderer/src/stores/__tests__/apply-app-event-route.test.ts
+++ b/src/renderer/src/stores/__tests__/apply-app-event-route.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { PENDING_NEW_SESSION_ID } from '@renderer/lib/session-ids'
 import { resolveAppEventRoute } from '../apply-app-event-route'
 
 const baseState = {
@@ -62,6 +63,30 @@ describe('resolveAppEventRoute', () => {
         },
       ),
     ).toBe('visible')
+  })
+
+  it('keeps old worker events out of a pending-new session', () => {
+    expect(
+      resolveAppEventRoute(
+        {
+          currentWorkspace: '/w/preview',
+          currentSessionId: PENDING_NEW_SESSION_ID,
+          historySessionFile: null,
+          workerLiveSnapshot: { sessionId: 'old-sid', sessionFile: '/tmp/old.jsonl' },
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          phase: 'delta',
+          text: 'old token',
+          seq: 1,
+          workspaceId: '/w/preview',
+          sessionFile: '/tmp/old.jsonl',
+          sessionId: 'old-sid',
+          timestamp: 1,
+        },
+      ),
+    ).toBe('background')
   })
 
   it('backgrounds events from another workspace', () => {

--- a/src/renderer/src/stores/__tests__/apply-app-event-run.test.ts
+++ b/src/renderer/src/stores/__tests__/apply-app-event-run.test.ts
@@ -8,6 +8,7 @@ vi.mock('@renderer/lib/alert-trace', () => ({
 }))
 vi.mock('@renderer/lib/abort-ui-hold', () => ({
   isAbortUiHoldActive: () => false,
+  isAbortQueueIgnoreActive: () => false,
 }))
 vi.mock('@renderer/lib/extension-ui-tool-sync', () => ({
   reconcileAllStaleInteractiveToolRows: vi.fn(),
@@ -43,7 +44,6 @@ function makeApi(): {
     streamingAssistantId: 'opt-asst-1',
     optimisticPendingUserText: null,
     agentTurnBootstrapping: false,
-    ignoreQueueSyncUntil: 0,
     runState,
     setRunState: (patch: Partial<RunState>) => {
       state.runState = { ...(state.runState as RunState), ...patch }
@@ -123,6 +123,26 @@ describe('handleRun idle (agent completion)', () => {
     expect((state.runState as RunState).status).toBe('idle')
     expect(state.streamingAssistantId).toBeNull()
     expect((state.workerLiveSnapshot as { status: string }).status).toBe('idle')
+  })
+
+  it('does not suppress a visible run because another session was just aborted', () => {
+    const { api, state } = makeApi()
+    state.historySessionFile = '/b.jsonl'
+    handleRun(
+      {
+        type: 'run',
+        phase: 'running',
+        seq: 2,
+        workspaceId: '/w',
+        sessionFile: '/b.jsonl',
+        runId: 'run-b',
+        timestamp: Date.now(),
+      } as never,
+      api,
+    )
+
+    expect((state.runState as RunState).status).toBe('running')
+    expect((state.runState as RunState).activeRunId).toBe('run-b')
   })
 
   it('run.state applies runtime model and surfaces modelFallbackMessage', async () => {

--- a/src/renderer/src/stores/__tests__/ui-store-runtime-slice.test.ts
+++ b/src/renderer/src/stores/__tests__/ui-store-runtime-slice.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useUIStore } from '../ui-store'
+
+describe('UI runtime state isolation', () => {
+  beforeEach(() => {
+    useUIStore.setState({
+      historySessionFile: '/sessions/current.jsonl',
+      sessionRuntimeRunning: {
+        '/sessions/current.jsonl': true,
+        '/sessions/background.jsonl': true,
+      },
+      streamingAssistantId: 'stale-assistant',
+      optimisticPendingUserText: 'stale prompt',
+      agentTurnBootstrapping: false,
+    })
+  })
+
+  it('clears terminal runtime UI only for the focused session', () => {
+    useUIStore.getState().reconcileSessionRuntimeIdle('/sessions/current.jsonl')
+
+    const state = useUIStore.getState()
+    expect(state.sessionRuntimeRunning).toEqual({ '/sessions/background.jsonl': true })
+    expect(state.streamingAssistantId).toBeNull()
+    expect(state.optimisticPendingUserText).toBeNull()
+    expect(state.agentTurnBootstrapping).toBe(false)
+  })
+
+  it('does not clear focused UI when a background session becomes idle', () => {
+    useUIStore.getState().reconcileSessionRuntimeIdle('/sessions/background.jsonl')
+
+    const state = useUIStore.getState()
+    expect(state.sessionRuntimeRunning).toEqual({ '/sessions/current.jsonl': true })
+    expect(state.streamingAssistantId).toBe('stale-assistant')
+    expect(state.optimisticPendingUserText).toBe('stale prompt')
+  })
+
+})

--- a/src/renderer/src/stores/__tests__/ui-store-stream-terminal-race.test.ts
+++ b/src/renderer/src/stores/__tests__/ui-store-stream-terminal-race.test.ts
@@ -69,7 +69,6 @@ describe('foreground stream terminal ordering', () => {
       agentTurnBootstrapping: false,
       pendingSteering: [],
       pendingFollowUp: [],
-      ignoreQueueSyncUntil: 0,
       sessionRuntimeRunning: { '/workspace/session.jsonl': true },
       workerLiveSnapshot: {
         sessionId: 'session-1',

--- a/src/renderer/src/stores/__tests__/visible-run-terminal-live-cache.test.ts
+++ b/src/renderer/src/stores/__tests__/visible-run-terminal-live-cache.test.ts
@@ -42,7 +42,6 @@ describe('visible run terminal retires stale live cache', () => {
       agentTurnBootstrapping: false,
       pendingSteering: [],
       pendingFollowUp: [],
-      ignoreQueueSyncUntil: 0,
       sessionRuntimeRunning: { [sessionFile]: true },
       workerLiveSnapshot: { sessionId: 'session-1', sessionFile, status: 'running' },
       runState: { status: 'running', activeRunId: 'run-1', toolCount: 0, errorCount: 0 },

--- a/src/renderer/src/stores/apply-app-event-route.ts
+++ b/src/renderer/src/stores/apply-app-event-route.ts
@@ -1,5 +1,6 @@
 import type { SessionScopedAppEvent } from '@shared/app-event-session'
 import { sessionFilesEqual } from '@renderer/lib/session-file-key'
+import { isPlaceholderSessionId } from '@renderer/lib/session-ids'
 
 export type AppEventRoute = 'visible' | 'background' | 'drop'
 
@@ -24,6 +25,8 @@ export function resolveAppEventRoute(state: RouteState, event: SessionScopedAppE
   const viewSid = state.currentSessionId
   const workerSid = state.workerLiveSnapshot.sessionId
   const evSid = event.sessionId
+
+  if (!viewFile && (!viewSid || isPlaceholderSessionId(viewSid))) return 'background'
 
   if (evFile) {
     if (viewFile && sessionFilesEqual(evFile, viewFile)) return 'visible'

--- a/src/renderer/src/stores/apply-app-event-run.ts
+++ b/src/renderer/src/stores/apply-app-event-run.ts
@@ -1,4 +1,4 @@
-import { isAbortUiHoldActive } from '@renderer/lib/abort-ui-hold'
+import { isAbortQueueIgnoreActive, isAbortUiHoldActive } from '@renderer/lib/abort-ui-hold'
 import { isViewingWorkerBoundSession } from '@renderer/lib/session-worker-sync'
 import { signalDesktopAlert } from '@renderer/lib/desktop-alerts'
 import { alertTrace } from '@renderer/lib/alert-trace'
@@ -40,18 +40,23 @@ function markViewIdle(state: ReturnType<StoreApi['get']>): void {
   }
 }
 
-export function handleRun(event: RunEvent, api: StoreApi): void {
+export function handleRun(event: RunEvent, api: StoreApi): boolean {
   const state = api.get()
   if (event.phase === 'started' || event.phase === 'running') {
-    if (isAbortUiHoldActive()) return
-    if (Date.now() < state.ignoreQueueSyncUntil && event.phase === 'running') return
-
     // Visible-route handler: still refuse to apply if event names a different session
     // (route bugs / unscoped events must not re-light the viewed session).
     const viewFile = state.historySessionFile
     const evFile = (event as { sessionFile?: string }).sessionFile
+    const eventSessionFile = evFile || viewFile
+    if (isAbortUiHoldActive(eventSessionFile)) return false
+    if (
+      event.phase === 'running' &&
+      isAbortQueueIgnoreActive(eventSessionFile)
+    ) {
+      return false
+    }
     if (viewFile && evFile && !isViewingWorkerBoundSession(viewFile, evFile)) {
-      return
+      return false
     }
 
     const runPatch: Record<string, unknown> = {
@@ -73,7 +78,7 @@ export function handleRun(event: RunEvent, api: StoreApi): void {
         status: 'running',
       })
     }
-    return
+    return true
   }
   if (event.phase === 'idle' || event.phase === 'cancelled') {
     flushStreamPendingSync(api.get, api.set)
@@ -88,7 +93,7 @@ export function handleRun(event: RunEvent, api: StoreApi): void {
         optimistic: !!s.optimisticPendingUserText,
         bootstrapping: s.agentTurnBootstrapping,
       })
-      return
+      return true
     }
     // Authoritative completion (pi agent_end / !isStreaming): clear all local turn markers.
     api.set({
@@ -120,7 +125,7 @@ export function handleRun(event: RunEvent, api: StoreApi): void {
         body: sec > 0 ? `Agent 已空闲（约 ${sec} 秒）` : 'Agent 已空闲，可继续输入',
       })
     }
-    return
+    return true
   }
   if (event.phase === 'failed') {
     flushStreamPendingSync(api.get, api.set)
@@ -139,7 +144,7 @@ export function handleRun(event: RunEvent, api: StoreApi): void {
     const evFile = (event as { sessionFile?: string }).sessionFile
     // Only apply model/thinking from the viewed session (or unscoped events).
     if (viewFile && evFile && !isViewingWorkerBoundSession(viewFile, evFile)) {
-      return
+      return false
     }
     const patch: Record<string, string | undefined> = {}
     if (event.model !== undefined) {
@@ -157,4 +162,5 @@ export function handleRun(event: RunEvent, api: StoreApi): void {
   if (event.toolStats) {
     state.setRunState({ toolCount: event.toolStats.total, errorCount: event.toolStats.failed })
   }
+  return true
 }

--- a/src/renderer/src/stores/apply-app-event.ts
+++ b/src/renderer/src/stores/apply-app-event.ts
@@ -12,6 +12,7 @@ import {
 } from '@renderer/stores/apply-app-event-handlers'
 import { applyBackgroundAppEvent, eventSessionFile } from '@renderer/stores/apply-app-event-background'
 import { markLiveSessionTurnEnded } from '@renderer/lib/live-session-timeline-cache'
+import { isAbortQueueIgnoreActive, shouldIgnoreAppEventAfterAbort } from '@renderer/lib/abort-ui-hold'
 import { reduceSubagentSessionGroupToolEvent } from '@renderer/lib/subagent-session-activity'
 import type { StoreApi } from '@renderer/stores/apply-app-event-types'
 
@@ -19,6 +20,7 @@ export type { StoreApi } from '@renderer/stores/apply-app-event-types'
 
 export function applyAppEvent(event: AppEvent, api: StoreApi): void {
   if (!isSessionScopedAppEvent(event)) return
+  if (shouldIgnoreAppEventAfterAbort(event)) return
   const state = api.get()
   if (event.type === 'tool' && state.subagentSessionGroup) {
     const nextGroup = reduceSubagentSessionGroupToolEvent(state.subagentSessionGroup, event)
@@ -50,9 +52,9 @@ export function applyAppEvent(event: AppEvent, api: StoreApi): void {
       })
       break
     case 'run': {
-      handleRun(event, api)
+      const accepted = handleRun(event, api)
       const sessionKey = eventSessionFile(event) || api.get().historySessionFile
-      if (sessionKey && (event.phase === 'running' || event.phase === 'started')) {
+      if (accepted && sessionKey && (event.phase === 'running' || event.phase === 'started')) {
         useUIStore.getState().setSessionRuntimeRunning(sessionKey, true)
       } else if (sessionKey && event.phase === 'idle') {
         if (api.get().runState.status === 'idle') {
@@ -72,7 +74,7 @@ export function applyAppEvent(event: AppEvent, api: StoreApi): void {
       handleSlash(event, api)
       break
     case 'queue':
-      if (Date.now() < state.ignoreQueueSyncUntil) {
+      if (isAbortQueueIgnoreActive(eventSessionFile(event) || state.historySessionFile)) {
         const hasQueued = (event.steering?.length ?? 0) > 0 || (event.followUp?.length ?? 0) > 0
         if (hasQueued) break
       }

--- a/src/renderer/src/stores/ui-store-runtime-slice.ts
+++ b/src/renderer/src/stores/ui-store-runtime-slice.ts
@@ -1,0 +1,57 @@
+import { normalizeSessionFileKey, sessionFilesEqual } from '@renderer/lib/session-file-key'
+import type { UIState } from '@renderer/stores/ui-store-types'
+
+type StoreSet = (
+  patch: Partial<UIState> | ((state: UIState) => Partial<UIState> | UIState),
+) => void
+
+type RuntimeSlice = Pick<
+  UIState,
+  'sessionRuntimeRunning' | 'setSessionRuntimeRunning' | 'reconcileSessionRuntimeIdle'
+>
+
+function runtimeKey(sessionFile: string): string {
+  return normalizeSessionFileKey(sessionFile) || String(sessionFile || '').trim()
+}
+
+function withoutSessionRuntime(
+  runtime: Record<string, boolean>,
+  sessionFile: string,
+): Record<string, boolean> {
+  const key = runtimeKey(sessionFile)
+  const next = { ...runtime }
+  for (const existing of Object.keys(next)) {
+    if (normalizeSessionFileKey(existing) === key) delete next[existing]
+  }
+  return next
+}
+
+export function createRuntimeSlice(set: StoreSet): RuntimeSlice {
+  return {
+    sessionRuntimeRunning: {},
+    setSessionRuntimeRunning: (sessionFile, running) =>
+      set((state) => {
+        const key = runtimeKey(sessionFile)
+        if (!key) return state
+        const next = withoutSessionRuntime(state.sessionRuntimeRunning, sessionFile)
+        if (running) next[key] = true
+        return { sessionRuntimeRunning: next }
+      }),
+    reconcileSessionRuntimeIdle: (sessionFile) =>
+      set((state) => {
+        const sessionRuntimeRunning = withoutSessionRuntime(
+          state.sessionRuntimeRunning,
+          sessionFile,
+        )
+        if (!sessionFilesEqual(state.historySessionFile, sessionFile)) {
+          return { sessionRuntimeRunning }
+        }
+        return {
+          sessionRuntimeRunning,
+          streamingAssistantId: null,
+          optimisticPendingUserText: null,
+          agentTurnBootstrapping: false,
+        }
+      }),
+  }
+}

--- a/src/renderer/src/stores/ui-store-types.ts
+++ b/src/renderer/src/stores/ui-store-types.ts
@@ -116,7 +116,6 @@ export interface AppEventStoreSlice {
   fileChanges: FileChange[]
   optimisticPendingUserText: string | null
   agentTurnBootstrapping: boolean
-  ignoreQueueSyncUntil: number
   pendingSteering: string[]
   pendingFollowUp: string[]
   rightPanelCatalog: RightPanelCatalogItem[]
@@ -197,6 +196,7 @@ export interface UIState {
   /** sessionFile → running (sidebar spinner) */
   sessionRuntimeRunning: Record<string, boolean>
   setSessionRuntimeRunning: (sessionFile: string, running: boolean) => void
+  reconcileSessionRuntimeIdle: (sessionFile: string) => void
   /**
    * Session-scoped tool row expand memory (toolCallId → expanded).
    * Display-only; not persisted across app restarts.
@@ -231,7 +231,5 @@ export interface UIState {
   pendingFollowUp: string[]
   setPendingQueue: (steering: string[], followUp: string[]) => void
   clearPendingQueue: () => void
-  ignoreQueueSyncUntil: number
-  markAbortQueueIgnore: (ms?: number) => void
   processEvent: (event: AppEvent) => void
 }

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -17,6 +17,8 @@ import {
   queueStreamDelta,
 } from '@renderer/stores/ui-store-stream'
 import { createShellSlice } from '@renderer/stores/ui-store-shell-slice'
+import { createRuntimeSlice } from '@renderer/stores/ui-store-runtime-slice'
+import { isAbortQueueIgnoreActive } from '@renderer/lib/abort-ui-hold'
 
 export type { TimelineItem, UIState } from '@renderer/stores/ui-store-types'
 
@@ -320,20 +322,7 @@ export const useUIStore = create<UIState>()(
   },
 
   ...createShellSlice(set, get),
-  sessionRuntimeRunning: {},
-  setSessionRuntimeRunning: (sessionFile, running) =>
-    set((s) => {
-      const key = normalizeSessionFileKey(sessionFile) || String(sessionFile || '').trim()
-      if (!key) return s
-      const next = { ...s.sessionRuntimeRunning }
-      // Drop any alias keys that normalize to the same path
-      for (const existing of Object.keys(next)) {
-        if (normalizeSessionFileKey(existing) === key) delete next[existing]
-      }
-      if (running) next[key] = true
-      else delete next[key]
-      return { sessionRuntimeRunning: next }
-    }),
+  ...createRuntimeSlice(set),
   lastModel: null,
   lastThinking: null,
   rememberModel: (model) => set({ lastModel: model }),
@@ -352,10 +341,9 @@ export const useUIStore = create<UIState>()(
   agentTurnBootstrapping: false,
   pendingSteering: [],
   pendingFollowUp: [],
-  ignoreQueueSyncUntil: 0,
-  markAbortQueueIgnore: (ms = 5000) => set({ ignoreQueueSyncUntil: Date.now() + ms }),
   setPendingQueue: (steering, followUp) => {
-    if (Date.now() < get().ignoreQueueSyncUntil) {
+    const state = get()
+    if (isAbortQueueIgnoreActive(state.historySessionFile)) {
       const hasQueued = steering.length > 0 || followUp.length > 0
       if (hasQueued) return
     }

--- a/src/worker/handlers/worker-handlers-catalog.test.ts
+++ b/src/worker/handlers/worker-handlers-catalog.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { handleGetmodels, handleReloadmodels } from './worker-handlers-catalog'
+import {
+  handleGetmodels,
+  handleGetsessioncontextpreview,
+  handleReloadmodels,
+} from './worker-handlers-catalog'
 import { st, type WorkerModelRuntime } from '../worker-runtime'
 
 function modelRuntimeWith(options?: {
@@ -15,6 +19,8 @@ function modelRuntimeWith(options?: {
 
 afterEach(() => {
   st.modelRuntime = null
+  st.session = null
+  st.currentSessionId = ''
 })
 
 describe('worker model catalog handlers', () => {
@@ -48,6 +54,29 @@ describe('worker model catalog handlers', () => {
         maxOutput: 0,
         available: true,
       }],
+    })
+  })
+})
+
+describe('worker context preview handler', () => {
+  it('uses the persisted-message metric even when the live session has a system prompt', async () => {
+    st.currentSessionId = 'session-a'
+    st.session = {
+      sessionFile: '/sessions/a.jsonl',
+      systemPrompt: 'live-only-system-prompt',
+      messages: [{ role: 'user', content: 'hello' }],
+    } as never
+    const reply = vi.fn()
+
+    await handleGetsessioncontextpreview({ sessionFile: '/sessions/a.jsonl' }, reply)
+
+    expect(reply).toHaveBeenCalledWith({
+      type: 'getSessionContextPreview-done',
+      preview: expect.objectContaining({
+        sessionFile: '/sessions/a.jsonl',
+        estimatedChars: 5,
+        roleBreakdown: [{ role: 'user', chars: 5 }],
+      }),
     })
   })
 })

--- a/src/worker/handlers/worker-handlers-catalog.ts
+++ b/src/worker/handlers/worker-handlers-catalog.ts
@@ -1,4 +1,4 @@
-import { extractTextFromPiMessage, type PiSessionMessage } from '@shared/worker-message'
+import { buildSessionContextPreview } from '@shared/session-context-preview'
 import { errorMessage } from '@shared/error-message'
 import type { WorkerCommandRow, WorkerIncomingMessage } from '../worker-port-types.js'
 import type { WorkerReply } from '../worker-handler-types.js'
@@ -91,89 +91,13 @@ export async function handleGetcommands(msg: WorkerIncomingMessage, reply: Worke
 
 export async function handleGetsessioncontextpreview(msg: WorkerIncomingMessage, reply: WorkerReply): Promise<void> {
         try {
-          const lines: string[] = []
-          const segments: { index: number; role: string; chars: number; preview: string; label?: string }[] = []
-          let msgCount = 0
-          let estChars = 0
-          const roleCharTotals: Record<string, number> = {}
-
-          const addRoleChars = (roleKey: string, chars: number) => {
-            if (chars <= 0) return
-            roleCharTotals[roleKey] = (roleCharTotals[roleKey] || 0) + chars
-          }
-
-          const normalizeRoleBucket = (role: string): string => {
-            if (role === 'user') return 'user'
-            if (role === 'assistant') return 'assistant'
-            if (role === 'toolResult' || role === 'tool') return 'tool'
-            if (role === 'system') return 'system'
-            if (role === 'compactionSummary' || role === 'branchSummary') return 'summary'
-            return 'other'
-          }
-
-          if (st.session) {
-            const systemPromptText =
-              typeof st.session.systemPrompt === 'string' ? st.session.systemPrompt : ''
-            const systemChars = systemPromptText.length
-            if (systemChars > 0) {
-              addRoleChars('system', systemChars)
-              estChars += systemChars
-              segments.push({
-                index: 0,
-                role: 'system',
-                chars: systemChars,
-                preview: systemPromptText.slice(0, 280),
-                label: 'system',
-              })
-            }
-
-            for (const m of st.session.messages || []) {
-              msgCount++
-              const hm = m as PiSessionMessage
-              const t = extractTextFromPiMessage(hm)
-              estChars += t.length
-              const role = hm.role || '?'
-              addRoleChars(normalizeRoleBucket(role), t.length)
-              let label: string | undefined
-              if (role === 'toolResult' && hm.toolName) label = hm.toolName
-              if (role === 'assistant' && Array.isArray(hm.content)) {
-                const tools = hm.content
-                  .filter((c) => (c as { type?: string }).type === 'toolCall')
-                  .map((c) => (c as { toolCall?: { name?: string } }).toolCall?.name)
-                  .filter(Boolean)
-                if (tools.length) label = tools.join(', ')
-              }
-              segments.push({
-                index: segments.length,
-                role,
-                chars: t.length,
-                preview: t.slice(0, 280),
-                label,
-              })
-              if (lines.length < 12 && t) {
-                lines.push(`[${role}] ${t.slice(0, 200)}${t.length > 200 ? '…' : ''}`)
-              }
-            }
-          }
-
-          const roleOrder = ['system', 'user', 'assistant', 'tool', 'summary', 'other'] as const
-          const roleBreakdown = roleOrder
-            .filter((key) => (roleCharTotals[key] || 0) > 0)
-            .map((key) => ({
-              role: key,
-              chars: roleCharTotals[key] || 0,
-            }))
-
           reply({
             type: 'getSessionContextPreview-done',
-            preview: {
+            preview: buildSessionContextPreview({
               sessionId: st.currentSessionId,
-              messageCount: msgCount,
-              estimatedChars: estChars,
-              snippets: lines,
-              segments,
-              roleBreakdown,
-            },
+              sessionFile: st.session?.sessionFile || String(msg.sessionFile || ''),
+              messages: st.session?.messages,
+            }),
           })
         } catch (e: unknown) {
           reply({ type: 'error', error: `getSessionContextPreview failed: ${errorMessage(e)}` })


### PR DESCRIPTION
## 概述

> 修复 Pi Desktop 多会话场景下的 **运行状态隔离** 与 **上下文使用量预览** 问题：
> 会话的运行状态、停止/中止控制、Worker 路由及上下文预览均严格归属于当前会话，不再跨会话泄漏。

## 问题

### 1. 运行状态跨会话泄漏

| 现象 | 说明 |
| --- | --- |
| 停止按钮误显示 | 会话 A 运行时，打开或新建的空闲会话 B 可能错误显示停止按钮 |
| 误操作影响他会话 | 在 B 点击停止可能中断 A——渲染进程与主进程仍共享全局运行状态和前台 Worker 状态 |
| Worker 复用错乱 | 新建会话时可能复用忙碌中的前台 Worker，导致初始化与运行事件关联到错误会话 |

### 2. 上下文使用量不准确

| 现象 | 说明 |
| --- | --- |
| 历史会话显示 0 | 未运行的历史会话可能一直显示 `0` |
| 数据残留 / 覆盖 | 切换会话后残留上一会话数据；旧会话延迟返回的请求可能覆盖当前结果 |
| 来源不一致 | 实时 Worker 与磁盘会话使用不同消息来源，同一会话在运行 / 空闲时显示不同用量 |

## 根因

- 运行状态未按 `sessionFile` 统一隔离，全局 `runState` 与前台 Worker 状态在切换会话后残留。
- 中止请求未强制携带目标会话，可能回退到前台 Worker。
- 新建会话未阻止复用运行中或停止中的 Worker。
- `context.preview` 未同时校验会话标识与工作区标识，磁盘回退路径缺少完整的隔离与授权校验。
- 渲染端未阻止旧会话延迟响应覆盖当前会话；实时与磁盘预览未统一使用持久化消息统计。

## 方案

### 运行状态隔离

1. **状态按会话存储**：按规范化后的 `sessionFile` 保存各会话运行状态；`runtime.getState` 与 `prompt.abort` 仅路由到指定会话，拒绝缺少会话标识的中止请求。
2. **Worker 生命周期管理**：禁止新会话复用运行中、停止中或已绑定其他会话的 Worker；经 WorkerManager 生命周期队列串行创建，前台 Worker 忙碌时为新会话分配独立 Worker；Worker 事件与会话重映射始终归属正确会话。
3. **UI 状态按会话清理**：中止冷却、停止按钮保持、队列事件过滤与乐观状态清理均按会话隔离；切换会话后不再依赖残留的全局运行状态，仅对当前会话应用权威空闲快照；删除 `composerTurnActive` 中已失效的全局状态参数。

### 上下文预览隔离

1. **统一预览逻辑**：新增共享的 `buildSessionContextPreview`，统一实时与磁盘预览；基于持久化会话消息与压缩感知的上下文数据计算用量，排除临时系统提示词状态。
2. **强制会话 + 工作区校验**：`context.preview` 强制要求：

   ```ts
   { sessionFile: string; workspaceId: string }
   ```

   实时查询仅访问对应会话的 Worker；仅通过当前可信工作区校验后才回退磁盘读取，并校验会话文件绝对路径、元数据 `cwd` 及 WSL 发行版身份。
3. **预览刷新与过期防护**：切换会话或历史记录变化时立即清除旧预览，忽略旧会话的延迟响应；历史加载完成、页面重新可见及当前会话运行期间主动刷新。

## 修改范围

- ✅ 仅涉及 Pi Desktop 的会话运行状态、UI 控制与上下文预览隔离
- ⛔ 不影响 CLI/Desktop 会话同步、模型渠道、计费语义及其他开放 PR
- ♻️ 现有会话文件和 CLI 记录保持兼容，无需迁移或删除

## 验证环境

| 项目 | 版本 |
| --- | --- |
| Pi Desktop | `0.5.6` |
| Electron | `43.0.0` |
| Pi coding agent | `0.83.0` |
| Node.js | `22.20.0` |
| npm | `10.9.3` |
| electron-builder | `26.15.3` |
| Vite | `8.1.3` |
| 系统 | macOS `27.0`（构建 `26A5388g`） |
| 架构 | Apple Silicon `arm64` |
| 上游基线 | `justhil/pi-app@29c522c` |
| PR 提交 | `88bab5f` |

## 自动化验证

- [x] 重点回归测试：12 个文件、56 个测试全部通过
- [x] 完整单元测试：140 个文件、655 个测试全部通过
- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过，无错误
- [x] 生产构建通过
- [x] ARM64 Electron 应用打包成功
- [x] `app.asar` 包含 `conf`、主进程上下文预览模块和渲染端预览 Hook
- [x] 安装后主进程与渲染进程稳定运行
- [x] 未发现 `ERR_MODULE_NOT_FOUND`、主进程未捕获异常或依赖解析错误

## 已手动验证

1. **停止按钮隔离**：会话 A 运行时打开或新建会话 B → B 不显示停止按钮；在 B 执行停止不影响 A；停止 A 后 B 保持空闲
2. **运行状态归属**：启动 B 后仅 B 显示运行状态；在运行 / 空闲会话间切换，各会话显示各自的上下文使用量
3. **历史会话用量**：打开含历史消息的空闲会话，上下文使用量不再为 `0`
4. **延迟响应防护**：快速切换会话，旧请求的延迟响应不覆盖当前会话
5. **并发创建**：有会话运行时连续新建多个会话，初始化与运行事件互不冲突

> **补充说明**：完整验证分支保留了额外诊断测试；本 PR 分支仅保留保护生产行为所需的关键回归测试