### PR TITLE
fix(sandbox): show background running status

### DIFF
--- a/src/renderer/src/features/workspace/project-sidebar-rows.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar-rows.tsx
@@ -329,6 +329,15 @@ export function SandboxDialogRow({
   onContextMenu: (e: React.MouseEvent) => void
 }) {
   const { t } = useTranslation()
+  const running = useUIStore((state) =>
+    !!(
+      box.sessionFile &&
+      Object.entries(state.sessionRuntimeRunning).some(
+        ([runtimeKey, isRunning]) =>
+          isRunning && sessionFilesEqual(runtimeKey, box.sessionFile),
+      )
+    ),
+  )
   const displayLabel =
     box.label?.trim() || t('common:sidebar.tempChat')
   return (
@@ -356,6 +365,12 @@ export function SandboxDialogRow({
           })}
         </div>
       </div>
+      {running ? (
+        <SessionRunningPixelGrid
+          className="ml-0.5 opacity-80"
+          title={t('common:status.running', { defaultValue: 'Running' })}
+        />
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
# 修复：临时会话运行中侧栏缺少动画指示

## 用户场景

沙盒或临时对话在**后台运行**时，侧栏应像普通项目会话一样显示运行动画；任务结束后，运行标记应自动消失。

## 问题原因

- 普通项目会话行已读取 `sessionRuntimeRunning`，使用规范化的 session file 匹配运行状态，并渲染 `SessionRunningPixelGrid` 组件。
- `SandboxDialogRow` **未读取或呈现同一运行状态**，导致后台沙盒即使仍在运行，侧栏也没有任何反馈。

## 解决方案

1. 在沙盒行中读取现有的 `sessionRuntimeRunning` 状态。
2. 复用 `sessionFilesEqual` 做文件匹配，避免不同路径表示导致匹配失败。
3. 复用普通会话已有的 `SessionRunningPixelGrid` 组件及其文案。
<img width="285" height="111" alt="image" src="https://github.com/user-attachments/assets/985048ee-9c92-4a27-82d7-fc982fbb09e0" />


## 改动范围

| 项目 | 内容 |
| --- | --- |
| 生产文件 | 1 个（+15 / -0） |
| 新增运行状态来源 | 无（不新增轮询或定时器） |
| 测试文件 | 未新增、未修改 |

> 说明：无 session file 或未运行的沙盒**不会**显示运行标记。

## 验证

- ✅ 分支 typecheck、lint、build 通过
- ✅ 集成分支现有单测、脚本测试和 E2E 全部通过
- ✅  后台运行、完成和空闲状态切换待手工验收