### PR TITLE
fix(session): isolate draft queue state

### DIFF
--- a/src/renderer/src/features/composer/slash-exec.ts
+++ b/src/renderer/src/features/composer/slash-exec.ts
@@ -9,6 +9,7 @@ import { ipcClient } from '@renderer/lib/ipc-client'
 import { useUIStore } from '@renderer/stores/ui-store'
 import { useExtensionUIStore } from '@renderer/stores/extension-ui-store'
 import { ensureAvailableModels } from '@renderer/lib/available-models-cache'
+import { enterBlankSession } from '@renderer/lib/blank-session-transition'
 
 /** App-native builtins handled directly in the renderer (not forwarded as plain prompt text). */
 const APP_BUILTIN = new Set([
@@ -136,12 +137,7 @@ export async function executeSlashCommand(
           toast.error(i18n.t('composer:toast.needWorkspace'))
           return true
         }
-        useExtensionUIStore.getState().resetForSessionContext()
-        store.clearTimeline()
-        store.setCurrentSession(null)
-        store.setWorkerLiveSnapshot({ sessionId: null, sessionFile: null, status: 'idle' })
-        store.setHistoryMeta(0, 0, null)
-        void ipcClient.invoke('session.setPendingBind', { sessionFile: null }).catch(() => {})
+        enterBlankSession('pending-project')
         void import('@renderer/lib/composer-run-display').then((m) => m.refreshComposerRunDisplay())
         toast.info(i18n.t('composer:toast.newSessionReady'))
       } catch (e) {

--- a/src/renderer/src/features/workspace/project-sidebar.tsx
+++ b/src/renderer/src/features/workspace/project-sidebar.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useUIStore } from '@renderer/stores/ui-store'
-import { useExtensionUIStore } from '@renderer/stores/extension-ui-store'
 import { ChevronRight, FolderOpen, Inbox, Plus } from '@renderer/components/icons'
 import { ipcClient } from '@renderer/lib/ipc-client'
 import { activateWorkspace } from '@renderer/lib/activate-workspace'
@@ -12,6 +11,7 @@ import { SessionContextMenuPortal } from './session-context-menu'
 import { useSessionContextMenu } from './use-session-context-menu'
 import { ProjectContextMenuPortal } from './project-context-menu'
 import { useProjectContextMenu } from './use-project-context-menu'
+import { enterBlankSession } from '@renderer/lib/blank-session-transition'
 import { refreshWorkspaceSessionLists } from '@renderer/lib/refresh-workspace-session-lists'
 import {
   diskProjectName,
@@ -177,7 +177,7 @@ export function ProjectSidebar({
   }
 
   const handleNewSandboxDialog = () => {
-    useUIStore.getState().enterEphemeralSandboxDraft()
+    enterBlankSession('ephemeral-sandbox')
     void import('@renderer/lib/composer-run-display').then((m) => m.refreshComposerRunDisplay())
   }
 
@@ -208,15 +208,7 @@ export function ProjectSidebar({
       if (workspacePath !== currentWorkspace) {
         await activateWorkspace(workspacePath, { preferHome: true })
       } else {
-        const store = useUIStore.getState()
-        store.clearPendingNewSessionPlaceholder()
-        useExtensionUIStore.getState().resetForSessionContext()
-        store.setCurrentSession(null)
-        store.setWorkerLiveSnapshot({ sessionId: null, sessionFile: null, status: 'idle' })
-        store.clearTimeline()
-        store.clearFileChanges()
-        store.setHistoryMeta(0, 0, null)
-        store.setSubagentSessionGroup(null)
+        enterBlankSession('pending-project')
         void import('@renderer/lib/composer-run-display').then((m) => m.refreshComposerRunDisplay())
       }
       setExpandedPaths((prev) => new Set(prev).add(workspacePath))

--- a/src/renderer/src/lib/activate-workspace.ts
+++ b/src/renderer/src/lib/activate-workspace.ts
@@ -10,6 +10,7 @@ import { captureVisibleLiveSessionTimeline } from '@renderer/lib/capture-live-se
 import { fetchWorkerLiveSnapshot } from '@renderer/lib/session-worker-sync'
 import { focusSessionSync } from '@renderer/lib/session-shell'
 import { sessionFilesEqual } from '@renderer/lib/session-file-key'
+import { enterBlankSession, resetBlankSessionProjection } from '@renderer/lib/blank-session-transition'
 
 export type ActivateWorkspaceOptions = {
   preferHome?: boolean
@@ -23,7 +24,8 @@ export type ActivateWorkspaceOptions = {
 export async function activateWorkspace(path: string, options?: ActivateWorkspaceOptions): Promise<void> {
   const navToken = beginSessionNavigation()
   const leavingWorkspace = useUIStore.getState().currentWorkspace
-  captureVisibleLiveSessionTimeline()
+  if (options?.preferHome) resetBlankSessionProjection()
+  else captureVisibleLiveSessionTimeline()
   if (leavingWorkspace && leavingWorkspace !== path) {
     void fetchWorkerLiveSnapshot(leavingWorkspace).catch(() => {})
   }
@@ -191,7 +193,7 @@ export async function switchSessionInPlace(sessionId: string, sessionFile?: stri
   store.clearPendingNewSessionPlaceholder()
 
   if (sessionId === PENDING_NEW_SESSION_ID) {
-    store.enterPendingNewSessionPlaceholder()
+    enterBlankSession('pending-project')
     return
   }
 

--- a/src/renderer/src/lib/blank-session-transition.ts
+++ b/src/renderer/src/lib/blank-session-transition.ts
@@ -1,0 +1,56 @@
+import { captureVisibleLiveSessionTimeline } from '@renderer/lib/capture-live-session-timeline'
+import { ipcClient } from '@renderer/lib/ipc-client'
+import { useExtensionUIStore } from '@renderer/stores/extension-ui-store'
+import { useUIStore } from '@renderer/stores/ui-store'
+
+export type BlankSessionKind = 'pending-project' | 'ephemeral-sandbox'
+
+function clearBlankSessionProjection(): void {
+  captureVisibleLiveSessionTimeline()
+
+  const state = useUIStore.getState()
+  state.clearTimeline()
+  useUIStore.setState({
+    pendingSteering: [],
+    pendingFollowUp: [],
+    optimisticPendingUserText: null,
+    agentTurnBootstrapping: false,
+    fileChanges: [],
+    historyTotalCount: 0,
+    historyLoadedCount: 0,
+    historySessionFile: null,
+    historyLoading: false,
+    subagentSessionGroup: null,
+    workerLiveSnapshot: { sessionId: null, sessionFile: null, status: 'idle' },
+    runState: {
+      ...state.runState,
+      status: 'idle',
+      activeRunId: undefined,
+      activeTool: undefined,
+      activeToolStatus: undefined,
+      toolCount: 0,
+      errorCount: 0,
+    },
+  })
+  useExtensionUIStore.getState().resetForSessionContext()
+}
+
+export function resetBlankSessionProjection(): void {
+  clearBlankSessionProjection()
+}
+
+export function enterBlankSession(kind: BlankSessionKind): void {
+  clearBlankSessionProjection()
+  useUIStore.setState({
+    ephemeralSandboxDraft: kind === 'ephemeral-sandbox',
+    pendingNewSessionPlaceholder: kind === 'pending-project',
+    ...(kind === 'ephemeral-sandbox' ? { currentWorkspace: null } : {}),
+    currentSessionId: kind === 'ephemeral-sandbox' ? '__ephemeral_draft__' : '__pending_new__',
+  })
+
+  if (kind === 'ephemeral-sandbox') {
+    void ipcClient.invoke('session.setEphemeralDraft', { active: true }).catch(() => {})
+  } else {
+    void ipcClient.invoke('session.setPendingBind', { sessionFile: null }).catch(() => {})
+  }
+}

--- a/src/renderer/src/lib/ensure-workspace-worker.ts
+++ b/src/renderer/src/lib/ensure-workspace-worker.ts
@@ -2,6 +2,7 @@ import { ipcClient } from '@renderer/lib/ipc-client'
 import { useUIStore } from '@renderer/stores/ui-store'
 import { refreshComposerRunDisplay } from '@renderer/lib/composer-run-display'
 import { resolveBootWorkspaceState } from '@renderer/lib/boot-workspace-state'
+import { enterBlankSession } from '@renderer/lib/blank-session-transition'
 let bootstrapping: Promise<void> | null = null
 
 /**
@@ -17,7 +18,7 @@ export function ensureWorkspaceWorkerOnBoot(): Promise<void> {
     const boot = resolveBootWorkspaceState(persisted)
     if (boot.ephemeralDraft) {
       void ipcClient.invoke('settings.set', { key: 'currentProject', value: null }).catch(() => {})
-      useUIStore.getState().enterEphemeralSandboxDraft()
+      enterBlankSession('ephemeral-sandbox')
       queueMicrotask(() => void refreshComposerRunDisplay())
       return
     }

--- a/src/renderer/src/lib/new-session.ts
+++ b/src/renderer/src/lib/new-session.ts
@@ -2,10 +2,11 @@ import { ipcClient } from '@renderer/lib/ipc-client'
 import { useUIStore } from '@renderer/stores/ui-store'
 import type { SessionItem } from '@renderer/stores/ui-store-types'
 import { titleFromFirstMessage } from '@renderer/lib/ephemeral-sandbox'
+import { enterBlankSession } from '@renderer/lib/blank-session-transition'
 
 /** 侧栏「新会话」：仅占位，不碰 Worker */
 export function enterNewSessionPlaceholder(): void {
-  useUIStore.getState().enterPendingNewSessionPlaceholder()
+  enterBlankSession('pending-project')
 }
 
 /** 首条消息：创建真实 session，并在拿到 sessionFile 后立即回调。 */

--- a/src/renderer/src/lib/session-shell.ts
+++ b/src/renderer/src/lib/session-shell.ts
@@ -192,7 +192,8 @@ export function captureFocusFromUiStore(): void {
         ? cloneItems(prev.items)
         : []
 
-  if (items.length === 0 && runUI === 'idle' && !prev) return
+  const hasPendingQueue = latest.pendingSteering.length > 0 || latest.pendingFollowUp.length > 0
+  if (items.length === 0 && runUI === 'idle' && !prev && !hasPendingQueue) return
 
   views.set(sessionKey, {
     sessionKey,

--- a/src/renderer/src/stores/ui-store-types.ts
+++ b/src/renderer/src/stores/ui-store-types.ts
@@ -128,9 +128,7 @@ export interface UIState {
   setWorkspace: (path: string | null) => void
   ephemeralSandboxDraft: boolean
   pendingNewSessionPlaceholder: boolean
-  enterEphemeralSandboxDraft: () => void
   clearEphemeralSandboxDraft: () => void
-  enterPendingNewSessionPlaceholder: (opts?: { keepTimeline?: boolean }) => void
   clearPendingNewSessionPlaceholder: () => void
   sessions: SessionItem[]
   currentSessionId: string | null

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -34,54 +34,6 @@ export const useUIStore = create<UIState>()(
   recentProjects: [],
   ephemeralSandboxDraft: false,
   pendingNewSessionPlaceholder: false,
-  enterEphemeralSandboxDraft: () => {
-    set({
-      ephemeralSandboxDraft: true,
-      pendingNewSessionPlaceholder: false,
-      currentWorkspace: null,
-      currentSessionId: '__ephemeral_draft__',
-      timelineItems: [],
-      streamingAssistantId: null,
-      fileChanges: [],
-      historyTotalCount: 0,
-      historyLoadedCount: 0,
-      historySessionFile: null,
-      historyLoading: false,
-      subagentSessionGroup: null,
-    })
-    void import('@renderer/lib/ipc-client').then(({ ipcClient }) =>
-      ipcClient.invoke('session.setEphemeralDraft', { active: true }).catch(() => {}),
-    )
-    void import('@renderer/stores/extension-ui-store').then(({ useExtensionUIStore }) =>
-      useExtensionUIStore.getState().resetForSessionContext(),
-    )
-  },
-  enterPendingNewSessionPlaceholder: (opts) => {
-    const keep = opts?.keepTimeline === true
-    set({
-      pendingNewSessionPlaceholder: true,
-      ephemeralSandboxDraft: false,
-      currentSessionId: '__pending_new__',
-      subagentSessionGroup: null,
-      ...(keep
-        ? {}
-        : {
-            timelineItems: [],
-            streamingAssistantId: null,
-            fileChanges: [],
-            historyTotalCount: 0,
-            historyLoadedCount: 0,
-            historySessionFile: null,
-            historyLoading: false,
-          }),
-    })
-    void import('@renderer/lib/ipc-client').then(({ ipcClient }) =>
-      ipcClient.invoke('session.setPendingBind', { sessionFile: null }).catch(() => {}),
-    )
-    void import('@renderer/stores/extension-ui-store').then(({ useExtensionUIStore }) =>
-      useExtensionUIStore.getState().resetForSessionContext(),
-    )
-  },
   clearPendingNewSessionPlaceholder: () => {
     set({ pendingNewSessionPlaceholder: false })
   },


### PR DESCRIPTION
# 修复：空白会话错误继承上一会话的排队消息

## 用户场景

当从一个正在运行的已有会话发送新信息进行排队时，打开一个新的会话，会话界面会显示前一个会话的排队信息：

![排队信息串会话](https://github.com/user-attachments/assets/6bae922b-069f-4440-aacf-f7573fc1635c)

从已有会话进入**项目新会话**、**临时会话**或 **`/new`** 时，空白草稿不应继承上一会话的排队消息、乐观消息或运行状态；切回原会话时，原会话自己的队列仍应保留。

## 问题原因

- 多个空白会话入口分别清理部分 UI 状态，转换契约不一致。
- 进入空白会话前没有统一捕获当前可见会话。
- 原入口遗漏 `pendingSteering`、`pendingFollowUp`、`optimisticPendingUserText`、bootstrapping 和 run chrome。
- 只有队列、没有 timeline item 的会话视图不会被缓存，导致返回时可能丢失队列。

## 解决方案

- 增加统一的 **blank-session transition**：切换前先调用现有会话捕获逻辑，再清空空白投影。
- 清理 timeline、排队状态、乐观消息、历史绑定、worker snapshot、run chrome 和 Extension UI。
- 允许 queue-only session view 被现有 session shell 捕获。
- 让**项目新会话**、**临时会话**、**`/new`**、**Project Home** 和 **worker boot** 入口使用同一转换。
- 删除旧的重复 store actions。

## 改动范围

- 9 个生产文件，**+73 / −74**。
- 队列继续由现有 session view / live timeline owner 保存和恢复。
- 不增加第二套队列 store。
- 未新增或修改测试文件。

## 验证

| 项目 | 结果 |
| --- | --- |
| `activate-workspace` 现有测试（3 项） | ✅ 通过 |
| 分支 typecheck | ✅ 通过 |
| 集成分支 typecheck / lint / build / 单测 / 脚本测试 / E2E | ✅ 全部通过 |
| 真实排队消息跨会话切换 | ✅  手工验收 |