### PR TITLE
fix(review): stabilize git workspace refresh

### DIFF
--- a/src/main/git-workspace-watch.ts
+++ b/src/main/git-workspace-watch.ts
@@ -18,6 +18,17 @@ let watcher: FSWatcher | null = null
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 let watchedCwd: string | null = null
 
+function shouldNotifyGitWorkspaceChange(filename: string | Buffer | null): boolean {
+  if (filename == null) return true
+  const basename = filename.toString().replace(/\\/g, '/').split('/').pop() || ''
+  return !(
+    basename.endsWith('.lock') ||
+    basename === 'gc.log' ||
+    basename === 'gc.pid' ||
+    basename === 'maintenance.lock'
+  )
+}
+
 function notifyGitChanged(win: BrowserWindow | null, cwd: string): void {
   if (!win || win.isDestroyed()) return
   win.webContents.send('ipc:git-workspace-changed', { cwd })
@@ -42,7 +53,8 @@ export function refreshGitWorkspaceWatch(win: BrowserWindow | null): void {
   }
   const gitDir = join(cwd, '.git')
   try {
-    watcher = watch(gitDir, { recursive: true }, () => {
+    watcher = watch(gitDir, { recursive: true }, (_eventType, filename) => {
+      if (!shouldNotifyGitWorkspaceChange(filename)) return
       if (debounceTimer) clearTimeout(debounceTimer)
       debounceTimer = setTimeout(() => {
         debounceTimer = null

--- a/src/main/git-workspace.ts
+++ b/src/main/git-workspace.ts
@@ -113,7 +113,7 @@ async function runGitReadOnly(
   if (!isGitRepository(cwd)) {
     return { ok: false, notRepo: true, message: '当前目录不是 Git 仓库' }
   }
-  const r = await gitExec(cwd, args, options)
+  const r = await gitExec(cwd, ['--no-optional-locks', ...args], options)
   if (r.status !== 0) {
     const message = (r.stderr || r.stdout || '').trim() || 'git 命令失败'
     if (isNotGitRepo(r.stderr, message)) {

--- a/src/renderer/src/features/review/review-panel.tsx
+++ b/src/renderer/src/features/review/review-panel.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@renderer/lib/utils'
 import { useUIStore } from '@renderer/stores/ui-store'
-import { ipcClient, onGitWorkspaceChanged } from '@renderer/lib/ipc-client'
 import { parseGitDiff } from '@shared/diff-model'
 import {
   Copy,
@@ -14,8 +13,8 @@ import {
   Columns2,
   Rows2,
 } from '@renderer/components/icons'
-import { parseGitStatus } from './review-git-utils'
 import { ChangeIcon, FileDiffView, ReviewCommitBar, type DiffMode } from './review-diff-views'
+import { useReviewGitData } from './use-review-git-data'
 
 type AnyFileEntry = {
   path: string
@@ -38,21 +37,15 @@ export function ReviewPanel() {
   const lastRunId = useUIStore((s) => s.runState.lastRunId)
   const running = useUIStore((s) => s.runState.status === 'running')
   const [copiedPath, setCopiedPath] = useState<string | null>(null)
-  const [gitData, setGitData] = useState<{
-    files: { path: string; changeType: string }[]
-    raw: string
-    branch?: string
-    log?: string
-    error?: string
-    isRepo?: boolean
-    message?: string
-  } | null>(null)
-  const [loading, setLoading] = useState(false)
   const [expandedGitPath, setExpandedGitPath] = useState<string | null>(null)
   const [focusGitPath, setFocusGitPath] = useState<string | null>(null)
   const [expandedMetaPath, setExpandedMetaPath] = useState<string | null>(null)
   const [diffMode, setDiffMode] = useState<DiffMode>('inline')
-  const [gitReloadKey, setGitReloadKey] = useState(0)
+  const { gitData, loading, refreshing, refresh: loadGit } = useReviewGitData({
+    enabled: scope === 'git',
+    workspace,
+    worktreeChangeSignal: fileChanges,
+  })
 
   const turnRunId = running ? activeRunId : lastRunId
 
@@ -89,41 +82,6 @@ export function ReviewPanel() {
     window.addEventListener('pi-desktop:review-focus-file', onFocus)
     return () => window.removeEventListener('pi-desktop:review-focus-file', onFocus)
   }, [])
-
-  const loadGit = () => {
-    if (!workspace) return
-    setLoading(true)
-    setGitReloadKey((k) => k + 1)
-    ipcClient
-      .invoke('review.getDiff', { sessionId: '', scope: 'git' })
-      .then((res) => {
-        if (res?.diff) {
-          const isRepo = res.diff.isRepo !== false
-          setGitData({
-            files: parseGitStatus(res.diff.status || ''),
-            raw: res.diff.raw || '',
-            branch: res.diff.branch,
-            log: res.diff.log,
-            isRepo,
-            message: res.diff.message,
-            error: isRepo ? res.diff.error : undefined,
-          })
-        }
-      })
-      .catch(() => setGitData(null))
-      .finally(() => setLoading(false))
-  }
-
-  useEffect(() => {
-    if (scope === 'git' && workspace) loadGit()
-  }, [scope, workspace])
-
-  useEffect(() => {
-    return onGitWorkspaceChanged((payload) => {
-      if (!workspace || payload.cwd.replace(/\\/g, '/') !== workspace.replace(/\\/g, '/')) return
-      if (scope === 'git') loadGit()
-    })
-  }, [scope, workspace])
 
   const turnFiles = useMemo(
     () => fileChanges.filter((f) => turnRunId && f.runId === turnRunId),
@@ -191,7 +149,7 @@ export function ReviewPanel() {
           )}
           {scope === 'git' && (
             <button type="button" onClick={loadGit} className="chrome-icon-btn rounded p-1" title={t('review:refresh')}>
-              <RefreshCw className={cn('h-3 w-3', loading && 'animate-spin')} />
+              <RefreshCw className={cn('h-3 w-3', (loading || refreshing) && 'animate-spin')} />
             </button>
           )}
         </div>
@@ -233,7 +191,7 @@ export function ReviewPanel() {
               const file = diffFiles.find((d) => d.path === fc.path || fc.path.endsWith(d.path))
               return (
                 <FileDiffView
-                  key={`${fc.path}-${gitReloadKey}`}
+                  key={fc.path}
                   file={file}
                   fallbackPath={fc.path}
                   fallbackChangeType={fc.changeType}

--- a/src/renderer/src/features/review/use-review-git-data.ts
+++ b/src/renderer/src/features/review/use-review-git-data.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ipcClient, onGitWorkspaceChanged } from '@renderer/lib/ipc-client'
+import { parseGitStatus } from './review-git-utils'
+
+export type ReviewGitData = {
+  files: { path: string; changeType: string; staged: boolean }[]
+  raw: string
+  branch?: string
+  log?: string
+  error?: string
+  isRepo?: boolean
+  message?: string
+  snapshotKey: string
+}
+
+type RawGitDiff = {
+  raw?: string
+  status?: string
+  branch?: string
+  log?: string
+  error?: string
+  isRepo?: boolean
+  message?: string
+}
+
+function normalizeGitData(diff: RawGitDiff): ReviewGitData {
+  const isRepo = diff.isRepo !== false
+  const raw = diff.raw || ''
+  const status = diff.status || ''
+  const branch = diff.branch
+  const log = diff.log
+  const message = diff.message
+  const error = isRepo ? diff.error : undefined
+  return {
+    files: parseGitStatus(status),
+    raw,
+    branch,
+    log,
+    isRepo,
+    message,
+    error,
+    snapshotKey: JSON.stringify([raw, status, branch, log, isRepo, message, error]),
+  }
+}
+
+export function useReviewGitData(options: {
+  enabled: boolean
+  workspace: string | null
+  worktreeChangeSignal: unknown
+}) {
+  const { enabled, workspace, worktreeChangeSignal } = options
+  const identity = enabled && workspace ? workspace.replace(/\\/g, '/') : ''
+  const identityRef = useRef(identity)
+  identityRef.current = identity
+  const dataRef = useRef<{ identity: string; data: ReviewGitData | null }>({
+    identity: '',
+    data: null,
+  })
+  const inFlightRef = useRef<Promise<void> | null>(null)
+  const queuedRef = useRef(false)
+  const refreshRef = useRef<() => Promise<void>>(async () => {})
+  const [state, setState] = useState<{
+    identity: string
+    data: ReviewGitData | null
+    loading: boolean
+    refreshing: boolean
+  }>({ identity: '', data: null, loading: false, refreshing: false })
+
+  const refresh = useCallback(async (): Promise<void> => {
+    const requestIdentity = identityRef.current
+    if (!requestIdentity) return
+    if (inFlightRef.current) {
+      queuedRef.current = true
+      return inFlightRef.current
+    }
+
+    const currentData = dataRef.current.identity === requestIdentity ? dataRef.current.data : null
+    setState({
+      identity: requestIdentity,
+      data: currentData,
+      loading: !currentData,
+      refreshing: !!currentData,
+    })
+    const request = (async () => {
+      try {
+        const response = await ipcClient.invoke('review.getDiff', { sessionId: '', scope: 'git' })
+        if (identityRef.current !== requestIdentity) return
+        const next = normalizeGitData((response?.diff || {}) as RawGitDiff)
+        const previous = dataRef.current.identity === requestIdentity ? dataRef.current.data : null
+        const data = previous?.snapshotKey === next.snapshotKey ? previous : next
+        dataRef.current = { identity: requestIdentity, data }
+        setState({ identity: requestIdentity, data, loading: false, refreshing: false })
+      } catch {
+        if (identityRef.current !== requestIdentity) return
+        setState({ identity: requestIdentity, data: currentData, loading: false, refreshing: false })
+      }
+    })()
+    inFlightRef.current = request
+    await request.finally(() => {
+      if (inFlightRef.current === request) inFlightRef.current = null
+      if (queuedRef.current) {
+        queuedRef.current = false
+        void refreshRef.current()
+      }
+    })
+  }, [])
+  refreshRef.current = refresh
+
+  useEffect(() => {
+    if (!identity) {
+      dataRef.current = { identity: '', data: null }
+      setState({ identity: '', data: null, loading: false, refreshing: false })
+      return
+    }
+    void refresh()
+  }, [identity, worktreeChangeSignal, refresh])
+
+  useEffect(() => {
+    if (!identity) return
+    return onGitWorkspaceChanged((payload) => {
+      if (payload.cwd.replace(/\\/g, '/') === identityRef.current) void refresh()
+    })
+  }, [identity, refresh])
+
+  const visible = state.identity === identity ? state : null
+  return {
+    gitData: visible?.data || null,
+    loading: visible?.loading || false,
+    refreshing: visible?.refreshing || false,
+    refresh,
+  }
+}


### PR DESCRIPTION
# 修复：Review Git 工作区打开后持续闪烁

## 用户场景

打开 Review 的 Git 工作区后，界面一直闪烁：

<img width="804" height="832" alt="d03c895b0cce8830a08f387967654c50" src="https://github.com/user-attachments/assets/7789712b-f759-4039-b5fc-cd906daad584" />
<img width="704" height="972" alt="81a9a4dc307d1fcca43e49830dcbd784" src="https://github.com/user-attachments/assets/e62babad-38ae-443d-939a-93e0fd2ad067" />

**预期行为**：文件变化应触发刷新，但现有内容不应被反复整块 loading 替换，文件列表也不应持续收折或闪烁。

## 问题原因

Git 读取产生的瞬时锁或维护文件反馈给 watcher，renderer 再将每次刷新放大成 spinner 和文件视图重挂。具体链路：

1. Git 快照读取虽已异步，但只读命令**未禁用 optional locks**。
2. `.git` watcher 对临时 lock、gc 和 maintenance 文件事件**也会发送刷新通知**。
3. renderer 允许多个刷新请求**重叠**，每次刷新都切换到整块 loading。
4. 递增的 reload key 被写入文件视图 React key，**等价快照也会重新挂载列表**。

## 解决方案

1. 为只读 Git 快照命令统一增加 `--no-optional-locks`。
2. 过滤 `.lock`、`gc.log`、`gc.pid`、`maintenance.lock` 等 watcher 噪声，同时保留 HEAD、ref 和 index 等真实变化。
3. 使用 **single-flight 刷新**：同一时间只执行一个请求，最多保留一次后续补刷。
4. 拒绝属于旧 workspace 的过期响应。
5. 使用稳定 snapshot，等价结果复用原对象。
6. 后台刷新期间保留现有内容，仅首次无数据加载时显示整块 loading。
7. 使用稳定文件路径作为 React key。

## 改动范围

| 项目 | 内容 |
| --- | --- |
| 生产文件 | 4 个（+155 / -53） |
| 新增定时器 / 焦点轮询 | 无 |
| 既有能力 | 保留 watcher、手动刷新、renderer worktree 信号 |
| 测试文件 | 未新增、未修改 |

## 验证

- ✅ 分支 typecheck、lint、build 通过
- ✅ 集成分支 typecheck、lint、build、843 项单测、273 项脚本测试和 12 项 E2E 全部通过
- ✅ 持续编辑文件及执行 add、commit、checkout 时的视觉稳定性已手工验收