### PR TITLE
fix(questionnaire): render native selection controls

### DIFF
--- a/src/renderer/src/features/extension-ui/questionnaire-dialog.tsx
+++ b/src/renderer/src/features/extension-ui/questionnaire-dialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { X } from '@renderer/components/icons'
 import { cn } from '@renderer/lib/utils'
+import { QuestionnaireOptions } from './questionnaire-options'
+import { QuestionnaireFooter } from './questionnaire-footer'
 
 export type AskQuestionPayload = {
   question: string
@@ -29,11 +31,12 @@ export function QuestionnaireDialog({
   const [singleChoice, setSingleChoice] = useState<Record<number, string>>({})
   const [multiChoice, setMultiChoice] = useState<Record<number, string[]>>({})
   const [customText, setCustomText] = useState<Record<number, string>>({})
+  const [previewChoice, setPreviewChoice] = useState<Record<number, string>>({})
 
   const q = questions[tab]
   const isLast = tab >= questions.length - 1
 
-  const submitAll = () => {
+  const submitAll = (single = singleChoice) => {
     const answers = questions.map((question, questionIndex) => {
       const custom = customText[questionIndex]?.trim()
       if (custom) {
@@ -52,7 +55,7 @@ export function QuestionnaireDialog({
         questionIndex,
         question: question.question,
         kind: 'option' as const,
-        answer: singleChoice[questionIndex] || null,
+        answer: single[questionIndex] || null,
       }
     })
     onSubmit({ cancelled: false, answers })
@@ -71,58 +74,26 @@ export function QuestionnaireDialog({
   const hasPreviewLayout =
     !q.multiSelect && q.options.some((o) => typeof o.preview === 'string' && o.preview.length > 0)
   const selectedLabel = singleChoice[tab]
-  const previewOpt = q.options.find((o) => o.label === selectedLabel)
+  const previewOpt = q.options.find((o) => o.label === (previewChoice[tab] || selectedLabel))
   const previewText =
     typeof previewOpt?.preview === 'string' && previewOpt.preview.length > 0
       ? previewOpt.preview
       : q.options.find((o) => typeof o.preview === 'string' && o.preview)?.preview
 
-  const optionList = (
-    <div className="space-y-2">
-      {q.options.map((opt) => {
-        const checked = q.multiSelect
-          ? (multiChoice[tab] || []).includes(opt.label)
-          : singleChoice[tab] === opt.label
-        return (
-          <button
-            key={opt.label}
-            type="button"
-            onClick={() => {
-              if (q.multiSelect) {
-                const prev = multiChoice[tab] || []
-                setMultiChoice({
-                  ...multiChoice,
-                  [tab]: checked ? prev.filter((x) => x !== opt.label) : [...prev, opt.label],
-                })
-              } else {
-                setSingleChoice({ ...singleChoice, [tab]: opt.label })
-              }
-            }}
-            className={cn(
-              'flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors',
-              checked ? 'border-primary/50 bg-accent' : 'hover:bg-accent/40',
-            )}
-          >
-            <span
-              className={cn(
-                'mt-1 h-3.5 w-3.5 shrink-0 rounded-full border-2',
-                checked ? 'border-primary bg-primary' : 'border-muted-foreground/40',
-              )}
-            />
-            <div className="min-w-0">
-              <div className="text-[13px] font-medium">{opt.label}</div>
-              {opt.description && (
-                <div className="text-[12px] text-muted-foreground">{opt.description}</div>
-              )}
-              {opt.hasPreview && !opt.preview && (
-                <div className="text-[10px] text-amber-600/80">含预览（选此项后右侧显示）</div>
-              )}
-            </div>
-          </button>
-        )
-      })}
-    </div>
-  )
+  const chooseSingle = (label: string) => {
+    const next = { ...singleChoice, [tab]: label }
+    setSingleChoice(next)
+    if (isLast) submitAll(next)
+    else setTab(tab + 1)
+  }
+
+  const toggleMulti = (label: string, checked: boolean) => {
+    const previous = multiChoice[tab] || []
+    setMultiChoice({
+      ...multiChoice,
+      [tab]: checked ? [...previous, label] : previous.filter((value) => value !== label),
+    })
+  }
 
   return (
     <div
@@ -162,7 +133,23 @@ export function QuestionnaireDialog({
             hasPreviewLayout && 'grid grid-cols-1 gap-4 md:grid-cols-2',
           )}
         >
-          <div>{optionList}</div>
+          <div>
+            <QuestionnaireOptions
+              question={q}
+              singleValue={singleChoice[tab]}
+              multiValue={multiChoice[tab] || []}
+              onSingleChange={chooseSingle}
+              onMultiChange={toggleMulti}
+              onPreview={(label) => setPreviewChoice({ ...previewChoice, [tab]: label })}
+            />
+            <textarea
+              className="mt-4 w-full rounded-md border border-input bg-background px-3 py-2 text-[13px]"
+              rows={2}
+              placeholder="自定义答案…"
+              value={customText[tab] || ''}
+              onChange={(e) => setCustomText({ ...customText, [tab]: e.target.value })}
+            />
+          </div>
           {hasPreviewLayout && (
             <div className="min-h-[120px] rounded-lg border border-border/60 bg-muted/30 p-3">
               <div className="mb-2 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/60">
@@ -177,63 +164,18 @@ export function QuestionnaireDialog({
               )}
             </div>
           )}
-          {!hasPreviewLayout && !q.multiSelect && (
-            <textarea
-              className="mt-4 w-full rounded-md border border-input bg-background px-3 py-2 text-[13px]"
-              rows={2}
-              placeholder="自定义答案…"
-              value={customText[tab] || ''}
-              onChange={(e) => setCustomText({ ...customText, [tab]: e.target.value })}
-            />
-          )}
         </div>
 
-        <div className="flex justify-between border-t px-5 py-3">
-          <div className="flex gap-3">
-            <button
-              type="button"
-              className="text-[13px] text-muted-foreground hover:text-foreground"
-              onClick={onSuspend}
-            >
-              稍后作答
-            </button>
-            <button
-              type="button"
-              className="text-[13px] text-destructive/80 hover:text-destructive"
-              onClick={onCancel}
-            >
-              取消并通知扩展
-            </button>
-          </div>
-          <div className="flex gap-2">
-            {tab > 0 && (
-              <button
-                type="button"
-                className="rounded-md border px-3 py-1.5 text-[13px]"
-                onClick={() => setTab(tab - 1)}
-              >
-                上一题
-              </button>
-            )}
-            {!isLast ? (
-              <button
-                type="button"
-                className="rounded-md bg-primary px-3 py-1.5 text-[13px] text-primary-foreground"
-                onClick={() => setTab(tab + 1)}
-              >
-                下一题
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="rounded-md bg-primary px-3 py-1.5 text-[13px] text-primary-foreground"
-                onClick={submitAll}
-              >
-                提交
-              </button>
-            )}
-          </div>
-        </div>
+        <QuestionnaireFooter
+          tab={tab}
+          isLast={isLast}
+          canAdvance={!!q.multiSelect || !!customText[tab]?.trim()}
+          onPrevious={() => setTab(tab - 1)}
+          onNext={() => setTab(tab + 1)}
+          onSubmit={() => submitAll()}
+          onSuspend={onSuspend}
+          onCancel={onCancel}
+        />
       </div>
     </div>
   )

--- a/src/renderer/src/features/extension-ui/questionnaire-footer.tsx
+++ b/src/renderer/src/features/extension-ui/questionnaire-footer.tsx
@@ -1,0 +1,50 @@
+type QuestionnaireFooterProps = {
+  tab: number
+  isLast: boolean
+  canAdvance: boolean
+  onPrevious: () => void
+  onNext: () => void
+  onSubmit: () => void
+  onSuspend: () => void
+  onCancel: () => void
+}
+
+export function QuestionnaireFooter({
+  tab,
+  isLast,
+  canAdvance,
+  onPrevious,
+  onNext,
+  onSubmit,
+  onSuspend,
+  onCancel,
+}: QuestionnaireFooterProps) {
+  return (
+    <div className="flex justify-between border-t px-5 py-3">
+      <div className="flex gap-3">
+        <button type="button" className="text-[13px] text-muted-foreground hover:text-foreground" onClick={onSuspend}>
+          稍后作答
+        </button>
+        <button type="button" className="text-[13px] text-destructive/80 hover:text-destructive" onClick={onCancel}>
+          取消并通知扩展
+        </button>
+      </div>
+      <div className="flex gap-2">
+        {tab > 0 && (
+          <button type="button" className="rounded-md border px-3 py-1.5 text-[13px]" onClick={onPrevious}>
+            上一题
+          </button>
+        )}
+        {canAdvance && (
+          <button
+            type="button"
+            className="rounded-md bg-primary px-3 py-1.5 text-[13px] text-primary-foreground"
+            onClick={isLast ? onSubmit : onNext}
+          >
+            {isLast ? '提交' : '下一题'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/features/extension-ui/questionnaire-options.tsx
+++ b/src/renderer/src/features/extension-ui/questionnaire-options.tsx
@@ -1,0 +1,57 @@
+import type { AskQuestionPayload } from './questionnaire-dialog'
+
+type QuestionnaireOptionsProps = {
+  question: AskQuestionPayload
+  singleValue?: string
+  multiValue: string[]
+  onSingleChange: (label: string) => void
+  onMultiChange: (label: string, checked: boolean) => void
+  onPreview: (label: string) => void
+}
+
+export function QuestionnaireOptions({
+  question,
+  singleValue,
+  multiValue,
+  onSingleChange,
+  onMultiChange,
+  onPreview,
+}: QuestionnaireOptionsProps) {
+  return (
+    <div className="space-y-2">
+      {question.options.map((option) => {
+        const checked = question.multiSelect
+          ? multiValue.includes(option.label)
+          : singleValue === option.label
+        return (
+          <label
+            key={option.label}
+            className="flex w-full cursor-pointer items-start gap-3 rounded-md border px-3 py-2.5 text-left transition-colors has-[:checked]:border-primary/50 has-[:checked]:bg-accent hover:bg-accent/40"
+            onMouseEnter={() => onPreview(option.label)}
+            onFocus={() => onPreview(option.label)}
+          >
+            <input
+              type={question.multiSelect ? 'checkbox' : 'radio'}
+              name={question.multiSelect ? undefined : `question-${question.question}`}
+              value={option.label}
+              checked={checked}
+              className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
+              onChange={(event) => {
+                if (question.multiSelect) onMultiChange(option.label, event.target.checked)
+                else onSingleChange(option.label)
+              }}
+            />
+            <span className="min-w-0">
+              <span className="block text-[13px] font-medium">{option.label}</span>
+              {option.description && (
+                <span className="block text-[12px] text-muted-foreground">
+                  {option.description}
+                </span>
+              )}
+            </span>
+          </label>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/worker/desktop-ui-bridge.ts
+++ b/src/worker/desktop-ui-bridge.ts
@@ -2,6 +2,16 @@
 
 import type { EventBus, Theme } from '@earendil-works/pi-coding-agent'
 import { randomUUID } from 'node:crypto'
+import type {
+  ExtensionUIQuestion,
+  ExtensionUIQuestionnaireResult,
+} from './questionnaire-types.js'
+
+export type {
+  ExtensionUIQuestion,
+  ExtensionUIQuestionAnswer,
+  ExtensionUIQuestionnaireResult,
+} from './questionnaire-types.js'
 
 export const ASK_USER_PROMPT_EVENT = 'rpiv:ask-user:prompt'
 
@@ -11,7 +21,13 @@ export type ExtensionUIRequest =
   | { id: string; method: 'input'; title: string; placeholder?: string; timeout?: number }
   | { id: string; method: 'editor'; title: string; prefill?: string }
   | { id: string; method: 'notify'; message: string; notifyType?: 'info' | 'warning' | 'error' }
-  | { id: string; method: 'custom'; kind: 'ask_user_question'; questions: unknown }
+  | {
+      id: string
+      method: 'custom'
+      kind: 'ask_user_question'
+      questions: ExtensionUIQuestion[]
+      toolCallId?: string
+    }
   | { id: string; method: 'custom'; kind: 'image_review'; image: string; title: string; question: string; context?: string; options: string[]; allowFeedback: boolean }
 
 type Pending = {
@@ -24,9 +40,21 @@ export type DesktopUIBridge = {
   uiContext: Record<string, unknown>
   handleExtensionUIResponse: (response: ExtensionUIResponse) => void
   handleExtensionUiCancel: (cancel: { id?: string; reason?: string }) => void
+  requestQuestionnaire: (
+    toolCallId: string,
+    questions: ExtensionUIQuestion[],
+    signal?: AbortSignal,
+  ) => Promise<ExtensionUIQuestionnaireResult>
   /** Cache interact args extracted by Worker (driven by adapter.json interact.fields). */
   setInteractArgs: (schema: 'questions' | 'review' | 'clarify', args: Record<string, unknown> | null) => void
   dispose: () => void
+}
+
+const bridgesByContext = new WeakMap<object, DesktopUIBridge>()
+
+export function getDesktopUIBridge(uiContext: unknown): DesktopUIBridge | null {
+  if (!uiContext || typeof uiContext !== 'object') return null
+  return bridgesByContext.get(uiContext as object) ?? null
 }
 
 export type ExtensionUIResponse = {
@@ -111,14 +139,14 @@ export function createDesktopUIBridge(
     lastAskPayload = payload as { questions: unknown }
   })
 
-  const buildAskQuestions = (): unknown[] => {
+  const buildAskQuestions = (): ExtensionUIQuestion[] => {
     // Prefer interact-cached questions (from tool args, has preview text) merged with event questions.
     type QRow = { options?: Array<{ preview?: string } & Record<string, unknown>> } & Record<string, unknown>
     const eventQs = (lastAskPayload?.questions as QRow[]) || []
     const interactQs = (interactArgs?.schema === 'questions' ? interactArgs.args.questions : null) as QRow[] | undefined
     const toolQs = interactQs || []
-    if (toolQs.length === 0) return eventQs
-    if (eventQs.length === 0) return toolQs
+    if (toolQs.length === 0) return eventQs as ExtensionUIQuestion[]
+    if (eventQs.length === 0) return toolQs as ExtensionUIQuestion[]
     return eventQs.map((eq, qi) => {
       const tq = toolQs[qi]
       if (!tq?.options) return eq
@@ -128,7 +156,7 @@ export function createDesktopUIBridge(
         return preview ? { ...eo, preview } : eo
       })
       return { ...eq, options: opts }
-    })
+    }) as ExtensionUIQuestion[]
   }
 
   const uiContext = {
@@ -250,7 +278,7 @@ export function createDesktopUIBridge(
     setToolsExpanded: () => {},
   }
 
-  return {
+  const bridge: DesktopUIBridge = {
     uiContext,
     handleExtensionUiCancel(cancel) {
       const p = cancel.id ? pending.get(cancel.id) : undefined
@@ -264,6 +292,21 @@ export function createDesktopUIBridge(
       p.cleanup()
       p.resolve(response)
     },
+    requestQuestionnaire(toolCallId, questions, signal) {
+      lastAskPayload = null
+      const id = randomUUID()
+      return createDialogPromise(
+        emitReq,
+        pending,
+        { id, method: 'custom', kind: 'ask_user_question', toolCallId, questions },
+        (response) =>
+          response.cancelled
+            ? { cancelled: true, answers: [] }
+            : (response.result as ExtensionUIQuestionnaireResult),
+        { cancelled: true, answers: [] },
+        { signal, ...dismissOpts },
+      )
+    },
     setInteractArgs(schema, args) {
       interactArgs = args ? { schema, args } : null
     },
@@ -275,6 +318,9 @@ export function createDesktopUIBridge(
         p.reject(new Error('UI bridge disposed'))
       }
       pending.clear()
+      bridgesByContext.delete(uiContext)
     },
   }
+  bridgesByContext.set(uiContext, bridge)
+  return bridge
 }

--- a/src/worker/questionnaire-rpc-ui.ts
+++ b/src/worker/questionnaire-rpc-ui.ts
@@ -1,0 +1,84 @@
+import type { ExtensionUIContext } from '@earendil-works/pi-coding-agent'
+import type {
+  ExtensionUIQuestion,
+  ExtensionUIQuestionAnswer,
+  ExtensionUIQuestionnaireResult,
+} from './desktop-ui-bridge.js'
+
+type QuestionnaireRequester = (
+  toolCallId: string,
+  questions: ExtensionUIQuestion[],
+  signal?: AbortSignal,
+) => Promise<ExtensionUIQuestionnaireResult>
+
+function matchingAnswer(
+  result: ExtensionUIQuestionnaireResult,
+  questionIndex: number,
+): ExtensionUIQuestionAnswer | undefined {
+  return result.answers.find((answer) => answer.questionIndex === questionIndex)
+}
+
+function rpcOptionValue(options: string[], label: string): string | undefined {
+  return options.find((option) => {
+    const withoutIndex = option.replace(/^\s*\d+\.\s*/, '')
+    return withoutIndex === label || withoutIndex.startsWith(`${label} `)
+  })
+}
+
+export function createQuestionnaireRpcUI(
+  base: ExtensionUIContext,
+  toolCallId: string,
+  questions: ExtensionUIQuestion[],
+  signal: AbortSignal | undefined,
+  request: QuestionnaireRequester,
+): ExtensionUIContext {
+  let resultPromise: Promise<ExtensionUIQuestionnaireResult> | null = null
+  let questionIndex = 0
+  let customInput: { questionIndex: number; answer: string } | null = null
+
+  const result = () => {
+    resultPromise ??= request(toolCallId, questions, signal)
+    return resultPromise
+  }
+
+  const select = async (_title: string, options: string[]): Promise<string | undefined> => {
+    const current = questionIndex++
+    const questionnaire = await result()
+    if (questionnaire.cancelled) return undefined
+    const answer = matchingAnswer(questionnaire, current)
+    if (!answer) return undefined
+    if (answer.kind === 'custom') {
+      customInput = { questionIndex: current, answer: answer.answer || '' }
+      return options.at(-1)
+    }
+    return answer.answer ? rpcOptionValue(options, answer.answer) : undefined
+  }
+
+  const input = async (): Promise<string | undefined> => {
+    if (customInput) {
+      const answer = customInput.answer
+      customInput = null
+      return answer
+    }
+    const current = questionIndex++
+    const questionnaire = await result()
+    if (questionnaire.cancelled) return undefined
+    const answer = matchingAnswer(questionnaire, current)
+    if (!answer) return undefined
+    if (answer.kind === 'multi') {
+      const selected = new Set(answer.selected || [])
+      return questions[current]?.options
+        .flatMap((option, index) => (selected.has(option.label) ? [String(index + 1)] : []))
+        .join(',')
+    }
+    return answer.answer || ''
+  }
+
+  return new Proxy(base, {
+    get(target, property, receiver) {
+      if (property === 'select') return select
+      if (property === 'input') return input
+      return Reflect.get(target, property, receiver)
+    },
+  })
+}

--- a/src/worker/questionnaire-tool-decorator.ts
+++ b/src/worker/questionnaire-tool-decorator.ts
@@ -1,0 +1,74 @@
+import type {
+  Extension,
+  ExtensionContext,
+  LoadExtensionsResult,
+  RegisteredTool,
+  ToolDefinition,
+} from '@earendil-works/pi-coding-agent'
+import { resolveV2ByPluginName } from '../extension-compat/adapter-loader.js'
+import {
+  getDesktopUIBridge,
+  type ExtensionUIQuestion,
+} from './desktop-ui-bridge.js'
+import { createQuestionnaireRpcUI } from './questionnaire-rpc-ui.js'
+
+function matchedToolName(extension: Extension, cwd: string): string | null {
+  const candidates = [extension.sourceInfo?.source, extension.path, extension.resolvedPath].filter(
+    (candidate): candidate is string => !!candidate,
+  )
+  for (const candidate of candidates) {
+    const adapter = resolveV2ByPluginName(candidate, candidate, cwd)
+    const interact = adapter?.interact
+    const toolName = interact?.trigger?.tool
+    if (interact?.schema === 'questions' && toolName && extension.tools.has(toolName)) {
+      return toolName
+    }
+  }
+  return null
+}
+
+function decorateTool(registered: RegisteredTool): RegisteredTool {
+  const definition = registered.definition as ToolDefinition
+  const execute = definition.execute.bind(definition)
+  return {
+    ...registered,
+    definition: {
+      ...definition,
+      executionMode: 'sequential',
+      async execute(toolCallId, params, signal, onUpdate, context) {
+        const bridge = getDesktopUIBridge(context.ui)
+        if (!bridge) return execute(toolCallId, params, signal, onUpdate, context)
+        const questions = (params as { questions?: ExtensionUIQuestion[] }).questions || []
+        const ui = createQuestionnaireRpcUI(
+          context.ui,
+          toolCallId,
+          questions,
+          signal,
+          (id, rows, abortSignal) => bridge.requestQuestionnaire(id, rows, abortSignal),
+        )
+        return execute(toolCallId, params, signal, onUpdate, {
+          ...context,
+          ui,
+        } as ExtensionContext)
+      },
+    },
+  }
+}
+
+export function decorateQuestionnaireTools(
+  result: LoadExtensionsResult,
+  cwd: string,
+): LoadExtensionsResult {
+  return {
+    ...result,
+    extensions: result.extensions.map((extension) => {
+      const toolName = matchedToolName(extension, cwd)
+      if (!toolName) return extension
+      const registered = extension.tools.get(toolName)
+      if (!registered) return extension
+      const tools = new Map(extension.tools)
+      tools.set(toolName, decorateTool(registered))
+      return { ...extension, tools }
+    }),
+  }
+}

--- a/src/worker/questionnaire-types.ts
+++ b/src/worker/questionnaire-types.ts
@@ -1,0 +1,24 @@
+export type ExtensionUIQuestion = {
+  question: string
+  header?: string
+  multiSelect?: boolean
+  options: Array<{
+    label: string
+    description?: string
+    hasPreview?: boolean
+    preview?: string
+  }>
+}
+
+export type ExtensionUIQuestionAnswer = {
+  questionIndex: number
+  question: string
+  kind: 'option' | 'multi' | 'custom'
+  answer: string | null
+  selected?: string[]
+}
+
+export type ExtensionUIQuestionnaireResult = {
+  cancelled: boolean
+  answers: ExtensionUIQuestionAnswer[]
+}

--- a/src/worker/worker-runtime.ts
+++ b/src/worker/worker-runtime.ts
@@ -9,6 +9,7 @@ import type {
 import type { AppEvent } from '@shared/app-events'
 import { formatSessionModelKey, type SessionModelRef } from '@shared/worker-model'
 import { createDesktopUIBridge, type DesktopUIBridge } from './desktop-ui-bridge.js'
+import { decorateQuestionnaireTools } from './questionnaire-tool-decorator.js'
 import {
   handleSessionEvent as dispatchSessionEvent,
   resetSessionEventTracking,
@@ -161,6 +162,7 @@ function buildRuntimeFactory(): CreateAgentSessionRuntimeFactory {
       agentDir,
       resourceLoaderOptions: {
         eventBus: st.sharedEventBus!,
+        extensionsOverride: (result) => decorateQuestionnaireTools(result, cwd),
       },
     })
     const created = await sdk.createAgentSessionFromServices({

--- a/src/worker/worker-session-events.ts
+++ b/src/worker/worker-session-events.ts
@@ -219,7 +219,7 @@ export function handleSessionEvent(event: AgentSessionEvent, deps: SessionEventD
     case 'tool_execution_start': {
       if (uiBridge && event.args) {
         const interact = resolveInteractByTool(event.toolName)
-        if (interact) {
+        if (interact && interact.schema !== 'questions') {
           const extracted: Record<string, unknown> = {}
           for (const [field, path] of Object.entries(interact.fields || {})) {
             extracted[field] = extractJsonPath(event.args, path)


### PR DESCRIPTION
# 修复：扩展问卷单选/多选控件与结果回放
我不确定是否符合设计，如果不符合就忽略吧～

## 用户场景

扩展问卷的**单选**应使用 radio，并在选择后立即进入下一题或提交；**多选**应使用 checkbox，允许选择多个选项，并由用户显式确认。

> 自定义答案、取消、稍后作答和多题顺序应继续可用。

**单选效果：**

![单选 radio](https://github.com/user-attachments/assets/b78ef6ed-2ded-4dda-953d-025835c926cd)

**多选效果：**

![多选 checkbox](https://github.com/user-attachments/assets/ea36b0b5-d611-46f7-8dc7-61db5fed5efb)

> 以上为可优化的表单效果参考，若与设计风格不符可忽略。

## 问题原因

- 当前 dialog 使用普通 button 和同一种圆形装饰表示单选与多选，多选缺少 checkbox 语义。
- Desktop 的结构化问卷结果与扩展原有的逐题 `ui.select`、`ui.input` 调用不是同一契约。
- 仅修改 renderer 控件不能让现有扩展正确接收问卷结果。

## 解决方案

- 使用**原生 radio 和 checkbox** 呈现选项。
- 单选在选择后**立即**进入下一题或提交。
- 多选只更新选择集合，通过显式按钮进入下一题或提交。
- 仅装饰 adapter 明确匹配且 schema 为 `questions` 的工具。
- 将一次结构化问卷结果映射回扩展原有的顺序式 `ui.select`、`ui.input` 调用。

## 改动范围

- 9 个生产文件，**+393 / −114**。
- 不修改 SDK 或已安装插件。
- 不影响未被 adapter 匹配的其他工具。
- 不纳入 Extension UI 跨会话持久化或重放。
- 未新增或修改测试文件。

## 验证

| 项目 | 结果 |
| --- | --- |
| 分支 typecheck / lint / build | 通过 |
| 集成分支 843 项单测 | 通过 |
| 集成分支 273 项脚本测试 | 通过 |
| 集成分支 12 项 E2E | 通过 |
| 实际插件单选 / 多选 / 自定义答案 / 取消 / 稍后作答 | 待手工验收 |

## 补充说明

此外我也发现了有问卷导致会话卡住的问题，但我看到你今天提交了一部分相关的修复跟我冲突了就没提交过来hh
累死我的 sol 了 OvO